### PR TITLE
[Parser] Fix transforming '>>' into '>' '>'

### DIFF
--- a/lldb/include/lldb/ValueObject/DILLexer.h
+++ b/lldb/include/lldb/ValueObject/DILLexer.h
@@ -136,6 +136,7 @@ class Token {
       m_kind(kind), m_spelling(std::move(spelling)), m_start_pos(start) {}
 
   Kind GetKind() const { return m_kind; }
+  void SetKind(Kind kind) { m_kind = kind; }
 
   std::string GetSpelling() const { return m_spelling; }
 
@@ -176,7 +177,7 @@ class DILLexer {
   static llvm::Expected<DILLexer> Create(llvm::StringRef expr);
 
   /// Return the current token to be handled by the DIL parser.
-  const Token& GetCurrentToken() { return m_lexed_tokens[m_tokens_idx]; }
+  Token &GetCurrentToken() { return m_lexed_tokens[m_tokens_idx]; }
 
   /// Advance the current token position by N.
   void Advance(uint32_t N = 1) {

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -2015,7 +2015,7 @@ std::string DILParser::ParseTypeName() {
       // consume it -- it will be done on the outer level when completing the
       // outer template argument list or C++-style cast.
       uint32_t loc = m_dil_token.GetLocation();
-      m_dil_token = Token(Token::greater, ">", loc);
+      m_dil_lexer.GetCurrentToken().SetKind(Token::greater);
       m_dil_lexer.InsertToken(Token(Token::greater, ">", loc+1));
 
     } else {

--- a/lldb/unittests/DIL/DILTests.cpp
+++ b/lldb/unittests/DIL/DILTests.cpp
@@ -2104,10 +2104,10 @@ TEST_F(EvalTest, TestTemplateCpp11) {
   // Template types lookup doesn't work well in the upstream LLDB.
   this->compare_with_lldb_ = false;
 
-  EXPECT_THAT(Eval("(T_1<T_1<int>>::myint)1"), XFail(IsEqual("1")));
-  EXPECT_THAT(Eval("(T_1<T_1<T_1<int>>>::myint)2"), XFail(IsEqual("2")));
+  EXPECT_THAT(Eval("(T_1<T_1<int>>::myint)1"), IsEqual("1"));
+  EXPECT_THAT(Eval("(T_1<T_1<T_1<int>>>::myint)2"), IsEqual("2"));
   EXPECT_THAT(Eval("(T_2<T_1<T_1<int>>, T_1<char>>::myint)1.5"),
-              XFail(IsEqual("1.5")));
+              IsEqual("1.5"));
 
   // Here T_1 is a local variable.
   EXPECT_THAT(Eval("T_1<2>1"), IsEqual("false"));  // (p < 2) > 1
@@ -2128,7 +2128,7 @@ TEST_F(EvalTest, TestTemplateWithNumericArguments) {
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
   // Test C++11's ">>" syntax.
   EXPECT_THAT(Eval("(TArray<int, Allocator<4>>::ElementType*)0"),
-              XFail(IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000")));
+              IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
 }
 
 #ifndef __EMSCRIPTEN__


### PR DESCRIPTION
Change current token kind in the token list instead of a current copy, because if a `TentativeParsingRollback` happens, it discards the changed copy.