### PR TITLE
[Parser] Check canonical types during type comparison

### DIFF
--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -547,7 +547,8 @@ static CompilerType UsualArithmeticConversions(
   }
 
   if (!is_comp_assign) {
-    assert(lhs->GetDereferencedResultType().CompareTypes(rhs->GetDereferencedResultType()) &&
+    assert(lhs->GetDereferencedResultType().GetCanonicalType().CompareTypes(
+               rhs->GetDereferencedResultType().GetCanonicalType()) &&
            "integral promotion error: operands result types must be the same");
   }
 
@@ -3364,6 +3365,12 @@ DILASTNodeUP DILParser::BuildTernaryOp(DILASTNodeUP cond, DILASTNodeUP lhs,
     return std::make_unique<TernaryOpNode>(location, lhs_type, std::move(cond),
                                            std::move(lhs), std::move(rhs));
   }
+  // If operands have the same canonical type, use the canonical type.
+  if (lhs_type.GetCanonicalType().CompareTypes(rhs_type.GetCanonicalType())) {
+    return std::make_unique<TernaryOpNode>(
+        location, lhs_type.GetCanonicalType(), std::move(cond), std::move(lhs),
+        std::move(rhs));
+  }
 
   // If both operands have arithmetic type, apply the usual arithmetic
   // conversions to bring them to a common type.
@@ -3388,6 +3395,12 @@ DILASTNodeUP DILParser::BuildTernaryOp(DILASTNodeUP cond, DILASTNodeUP lhs,
   if (lhs_type.CompareTypes(rhs_type)) {
     return std::make_unique<TernaryOpNode>(location, lhs_type, std::move(cond),
                                            std::move(lhs), std::move(rhs));
+  }
+  // Check if operands have the same canonical pointer type.
+  if (lhs_type.GetCanonicalType().CompareTypes(rhs_type.GetCanonicalType())) {
+    return std::make_unique<TernaryOpNode>(
+        location, lhs_type.GetCanonicalType(), std::move(cond), std::move(lhs),
+        std::move(rhs));
   }
 
   // If one operand is a pointer and the other is a nullptr or literal zero,

--- a/lldb/unittests/DIL/DILTests.cpp
+++ b/lldb/unittests/DIL/DILTests.cpp
@@ -3382,25 +3382,23 @@ TEST_F(EvalTest, TestTypeComparison) {
   // This test is for border-case situations in the CompareTypes function.
 
   // Taking an address of ternary expression require operands of the same type.
+  EXPECT_THAT(Eval("&(true ? i : mi)"), IsOk());
   EXPECT_THAT(Eval("&(true ? ip : icpc)"), IsOk());
-  EXPECT_THAT(Eval("&(true ? mipp : ipp)"),
-              XFail(IsOk(/*compare_types*/ false)));
+  EXPECT_THAT(Eval("&(true ? mipp : ipp)"), IsOk(/*compare_types*/ false));
   EXPECT_THAT(Eval("&(true ? ipp : icpcpc)"), IsOk());
-  EXPECT_THAT(Eval("&(true ? ipp : mipp)"), XFail(IsOk()));
+  EXPECT_THAT(Eval("&(true ? ipp : mipp)"), IsOk());
   EXPECT_THAT(Eval("&(true ? ipp : micpcpc)"), IsOk());
   // TODO: Enable type comparison once the type mismatch is fixed.
   // LLDB results in "int ***", while lldb-eval results in "MyInt ***".
-  EXPECT_THAT(Eval("&(true ? mipp : icpcpc)"),
-              XFail(IsOk(/*compare_types*/ false)));
-  EXPECT_THAT(Eval("&(true ? mipp : micpcpc)"),
-              XFail(IsOk(/*compare_types*/ false)));
+  EXPECT_THAT(Eval("&(true ? mipp : icpcpc)"), IsOk(/*compare_types*/ false));
+  EXPECT_THAT(Eval("&(true ? mipp : micpcpc)"), IsOk(/*compare_types*/ false));
   EXPECT_THAT(Eval("&(true ? icpcpc : micpcpc)"), IsOk());
 
   // Ensure that "signed char" and "char" are different types.
   EXPECT_THAT(Eval("true ? c : sc"), IsEqual("2")); // int
   EXPECT_THAT(Eval("true ? sc : (signed char)67"), IsEqual("'A'"));
   EXPECT_THAT(Eval("true ? (char)66 : (signed char)65"), IsEqual("66"));
-  EXPECT_THAT(Eval("true ? cc : mc"), XFail(IsEqual("'B'")));
+  EXPECT_THAT(Eval("true ? cc : mc"), IsEqual("'B'"));
   EXPECT_THAT(Eval("true ? cc : sc"), IsEqual("66"));
   EXPECT_THAT(Eval("true ? sc : mc"), IsEqual("65"));
   EXPECT_THAT(Eval("&(true ? c : c)"), IsOk());

--- a/lldb/unittests/DIL/Inputs/test_binary.cc
+++ b/lldb/unittests/DIL/Inputs/test_binary.cc
@@ -1098,6 +1098,7 @@ void TestTypeComparison() {
 
   using MyInt = int;
   using MyPtr = MyInt *;
+  MyInt mi = 2;
   MyPtr *mipp = ipp;
 
   using MyConstInt = const int;


### PR DESCRIPTION
The canonical type check is done in addition to user type check so that when the user types are identical, the returned result retains the user type.