### PR TITLE
Clean up DIL API python tests.

### DIFF
--- a/lldb/test/API/commands/frame/var-dil/basics/AddressOf/TestFrameVarDILFullAddressOf.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/AddressOf/TestFrameVarDILFullAddressOf.py
@@ -49,15 +49,15 @@ class TestFrameVarDILAddressOf(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable '&x'", patterns=["0x[0-9]+"])
         self.expect("frame variable 'r'", substrs=["42"])
         self.expect("frame variable '&r'", patterns=["0x[0-9]+"])
@@ -104,10 +104,6 @@ class TestFrameVarDILAddressOf(TestBase):
         self.expect("frame variable '&(true ? c : 1)'", error=True,
                     substrs=["cannot take the address of an rvalue of type "
                              "'int'"])
-
-        self.expect("frame variable '&this'", error=True,
-                    substrs=["cannot take the address of an rvalue of type "
-                             "'TestMethods *'"])
 
         self.expect("frame variable '&(&s_str)'", error=True,
                     substrs=["cannot take the address of an rvalue of type "

--- a/lldb/test/API/commands/frame/var-dil/basics/AddressOf/TestFrameVarDILStrippedAddressOf.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/AddressOf/TestFrameVarDILStrippedAddressOf.py
@@ -49,8 +49,8 @@ class TestFrameVarDILAddressOf(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
@@ -66,57 +66,21 @@ class TestFrameVarDILAddressOf(TestBase):
         self.expect("frame variable 'my_pr'", patterns=["0x[0-9]+"])
         self.expect("frame variable '&my_pr'", patterns=["0x[0-9]+"])
 
-        #self.expect("frame variable '&x == &r'", substrs=["true"])
-        #self.expect("frame variable '&x != &r'", substrs=["false"])
-
-        #self.expect("frame variable '&p == &pr'", substrs=["true"])
-        #self.expect("frame variable '&p != &pr'", substrs=["false"])
-        #self.expect("frame variable '&p == &my_pr'", substrs=["true"])
-        #self.expect("frame variable '&p != &my_pr'", substrs=["false"])
-
         self.expect("frame variable '&globalVar'", patterns=["0x[0-9]+"])
         self.expect("frame variable '&s_str'", patterns=["0x[0-9]+"])
         self.expect("frame variable '&param'", patterns=["0x[0-9]+"])
 
-        #self.expect("frame variable '&(true ? x : x)'",
-        #            patterns=["0x[0-9]+"])
-        #self.expect("frame variable '&(true ? c : c)'",
-        #            patterns=["0x[0-9]+"])
-
         self.expect("frame variable '&externGlobalVar'", error=True,
                     substrs=["use of undeclared identifier 'externGlobalVar'"])
-                    #substrs=["no variable or instance variable named 'externGlobalVar' found in this frame"])
 
         self.expect("frame variable '&1'", error=True,
                     substrs=["cannot take the address of an rvalue of type "
                              "'int'"])
-                    #substrs=["no variable or instance variable named '1' found in this frame"])
 
         self.expect("frame variable '&0.1'", error=True,
                     substrs=["cannot take the address of an rvalue of type "
                              "'double'"])
-                    #substrs=["no variable or instance variable named '0' found in this frame"])
-
-        #self.expect("frame variable '&(true ? 1 : 1)'", error=True,
-        #            substrs=["cannot take the address of an rvalue of type "
-        #                     "'int'"])
-
-        #self.expect("frame variable '&(true ? c : (char)1)'", error=True,
-        #            substrs=["cannot take the address of an rvalue of type "
-        #                     "'char'"])
-        #self.expect("frame variable '&(true ? c : 1)'", error=True,
-        #            substrs=["cannot take the address of an rvalue of type "
-        #                     "'int'"])
-
-        #self.expect("frame variable '&this'", error=True,
-        #            substrs=["cannot take the address of an rvalue of type "
-        #                     "'TestMethods *'"])
-        self.expect("frame variable '&this'", error=True,
-                    substrs=["cannot take the address of an rvalue of type "
-                             "'TestMethods *'"])
-                    #patterns=["0x[0-9]+"])
 
         self.expect("frame variable '&(&s_str)'", error=True,
                     substrs=["cannot take the address of an rvalue of type "
                              "'const char **'"])
-                    #substrs=["no variable or instance variable named '(' found in this frame"])

--- a/lldb/test/API/commands/frame/var-dil/basics/BitField/TestFrameVarDILFullBitField.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitField/TestFrameVarDILFullBitField.py
@@ -50,15 +50,15 @@ class TestFrameVarDILBitField(TestBase):
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
        # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
-        #
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
+
         # TestBitField
         #
         self.expect("frame variable 'bf.a'", substrs=["1023"])

--- a/lldb/test/API/commands/frame/var-dil/basics/BitField/TestFrameVarDILStrippedBitField.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitField/TestFrameVarDILStrippedBitField.py
@@ -49,8 +49,8 @@ class TestFrameVarDILBitField(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/BitwiseOperators/TestFrameVarDILFullBitwiseOperators.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitwiseOperators/TestFrameVarDILFullBitwiseOperators.py
@@ -49,15 +49,15 @@ class TestFrameVarDILBitwiseOperators(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         #
         # TestBitwiseOperators
         #
@@ -68,8 +68,8 @@ class TestFrameVarDILBitwiseOperators(TestBase):
         self.expect("frame variable '~~0'", substrs=["0"])
         self.expect("frame variable '~0'", substrs=["-1"])
         self.expect("frame variable '~1'", substrs=["-2"])
-        #self.expect("frame variable '~0LL'", substrs=["-1"])
-        #self.expect("frame variable '~1LL'", substrs=["-2"])
+        self.expect("frame variable '~0LL'", substrs=["-1"])
+        self.expect("frame variable '~1LL'", substrs=["-2"])
         self.expect("frame variable '~true'", substrs=["-2"])
         self.expect("frame variable '~false'", substrs=["-1"])
         self.expect("frame variable '~var_true'", substrs=["-2"])
@@ -87,16 +87,16 @@ class TestFrameVarDILBitwiseOperators(TestBase):
         self.expect("frame variable '(-1 >> 10)'", substrs=["-1"])
         self.expect("frame variable '(-100 >> 5)'", substrs=["-4"])
         self.expect("frame variable '(-3 << 6)'", substrs=["-192"])
-        #self.expect("frame variable '(2000000000U << 1)'", substrs=["4000000000"])
-        #self.expect("frame variable '(-1 >> 1U)'", substrs=["-1"])
+        self.expect("frame variable '(2000000000U << 1)'", substrs=["4000000000"])
+        self.expect("frame variable '(-1 >> 1U)'", substrs=["-1"])
         self.expect("frame variable '(char)1 << 16'", substrs=["65536"])
-        #self.expect("frame variable '(signed char)-123 >> 8'", substrs=["-1"])
+        self.expect("frame variable '(signed char)-123 >> 8'", substrs=["-1"])
 
-        #self.expect("frame variable '0b1011 & 0xFF'", substrs=["11"])
-        #self.expect("frame variable '0b1011 & mask_ff'", substrs=["11"])
-        #self.expect("frame variable '0b1011 & 0b0111'", substrs=["3"])
-        #self.expect("frame variable '0b1011 | 0b0111'", substrs=["15"])
-        #self.expect("frame variable -- '-0b1011 | 0xFF'", substrs=["-1"])
-        #self.expect("frame variable -- '-0b1011 | 0xFFu'", substrs=["4294967295"])
-        #self.expect("frame variable '0b1011 ^ 0b0111'", substrs=["12"])
-        #self.expect("frame variable '~0b1011'", substrs=["-12"])
+        self.expect("frame variable '0b1011 & 0xFF'", substrs=["11"])
+        self.expect("frame variable '0b1011 & mask_ff'", substrs=["11"])
+        self.expect("frame variable '0b1011 & 0b0111'", substrs=["3"])
+        self.expect("frame variable '0b1011 | 0b0111'", substrs=["15"])
+        self.expect("frame variable -- '-0b1011 | 0xFF'", substrs=["-1"])
+        self.expect("frame variable -- '-0b1011 | 0xFFu'", substrs=["4294967295"])
+        self.expect("frame variable '0b1011 ^ 0b0111'", substrs=["12"])
+        self.expect("frame variable '~0b1011'", substrs=["-12"])

--- a/lldb/test/API/commands/frame/var-dil/basics/BitwiseOperators/TestFrameVarDILStrippedBitwiseOperators.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitwiseOperators/TestFrameVarDILStrippedBitwiseOperators.py
@@ -49,15 +49,15 @@ class TestFrameVarDILBitwiseOperators(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         #
         # TestBitwiseOperators
         #
@@ -65,8 +65,8 @@ class TestFrameVarDILBitwiseOperators(TestBase):
         #self.expect("frame variable '~~0'", substrs=["0"])
         #self.expect("frame variable '~0'", substrs=["-1"])
         #self.expect("frame variable '~1'", substrs=["-2"])
-        #self.expect("frame variable '~0LL'", substrs=["-1"])
-        #self.expect("frame variable '~1LL'", substrs=["-2"])
+        self.expect("frame variable '~0LL'", substrs=["-1"])
+        self.expect("frame variable '~1LL'", substrs=["-2"])
         #self.expect("frame variable '~true'", substrs=["-2"])
         #self.expect("frame variable '~false'", substrs=["-1"])
         #self.expect("frame variable '~var_true'", substrs=["-2"])
@@ -84,16 +84,16 @@ class TestFrameVarDILBitwiseOperators(TestBase):
         #self.expect("frame variable '(-1 >> 10)'", substrs=["-1"])
         #self.expect("frame variable '(-100 >> 5)'", substrs=["-4"])
         #self.expect("frame variable '(-3 << 6)'", substrs=["-192"])
-        #self.expect("frame variable '(2000000000U << 1)'", substrs=["4000000000"])
-        #self.expect("frame variable '(-1 >> 1U)'", substrs=["-1"])
-        #self.expect("frame variable '(char)1 << 16'", substrs=["65536"])
+        self.expect("frame variable '(2000000000U << 1)'", substrs=["4000000000"])
+        self.expect("frame variable '(-1 >> 1U)'", substrs=["-1"])
+        self.expect("frame variable '(char)1 << 16'", substrs=["65536"])
         #self.expect("frame variable '(signed char)-123 >> 8'", substrs=["-1"])
 
-        #self.expect("frame variable '0b1011 & 0xFF'", substrs=["11"])
-        #self.expect("frame variable '0b1011 & mask_ff'", substrs=["11"])
-        #self.expect("frame variable '0b1011 & 0b0111'", substrs=["3"])
-        #self.expect("frame variable '0b1011 | 0b0111'", substrs=["15"])
-        #self.expect("frame variable -- '-0b1011 | 0xFF'", substrs=["-1"])
-        #self.expect("frame variable -- '-0b1011 | 0xFFu'", substrs=["4294967295"])
-        #self.expect("frame variable '0b1011 ^ 0b0111'", substrs=["12"])
-        #self.expect("frame variable '~0b1011'", substrs=["-12"])
+        self.expect("frame variable '0b1011 & 0xFF'", substrs=["11"])
+        self.expect("frame variable '0b1011 & mask_ff'", substrs=["11"])
+        self.expect("frame variable '0b1011 & 0b0111'", substrs=["3"])
+        self.expect("frame variable '0b1011 | 0b0111'", substrs=["15"])
+        self.expect("frame variable -- '-0b1011 | 0xFF'", substrs=["-1"])
+        self.expect("frame variable -- '-0b1011 | 0xFFu'", substrs=["4294967295"])
+        self.expect("frame variable '0b1011 ^ 0b0111'", substrs=["12"])
+        self.expect("frame variable '~0b1011'", substrs=["-12"])

--- a/lldb/test/API/commands/frame/var-dil/basics/GlobalVariableLookup/TestFrameVarDILFullGlobalVariableLookup.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/GlobalVariableLookup/TestFrameVarDILFullGlobalVariableLookup.py
@@ -49,16 +49,15 @@ class TestFrameVarDILGlobalVariableLookup(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable 'globalVar'", substrs=["-559038737"])  # 0xDEADBEEF
         self.expect("frame variable 'globalPtr'", patterns=["0x[0-9]+"])
         self.expect("frame variable 'globalRef'", substrs=["-559038737"])

--- a/lldb/test/API/commands/frame/var-dil/basics/GlobalVariableLookup/TestFrameVarDILStrippedGlobalVariableLookup.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/GlobalVariableLookup/TestFrameVarDILStrippedGlobalVariableLookup.py
@@ -49,8 +49,8 @@ class TestFrameVarDILGlobalVariableLookup(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
@@ -62,6 +62,7 @@ class TestFrameVarDILGlobalVariableLookup(TestBase):
         self.expect("frame variable 'globalVar'", substrs=["-559038737"])  # 0xDEADBEEF
         self.expect("frame variable 'globalPtr'", patterns=["0x[0-9]+"])
         self.expect("frame variable 'globalRef'", substrs=["-559038737"])
+        self.expect("frame variable '::globalVar'", substrs=["-559038737"])  # 0xDEADBEEF
         self.expect("frame variable '::globalPtr'", patterns=["0x[0-9]+"])
         self.expect("frame variable '::globalRef'", substrs=["-559038737"])
 

--- a/lldb/test/API/commands/frame/var-dil/basics/Indirection/TestFrameVarDILFullIndirection.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/Indirection/TestFrameVarDILFullIndirection.py
@@ -49,15 +49,15 @@ class TestFrameVarDILIndirection(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable '*p'", substrs=["1"])
         self.expect("frame variable 'p'", patterns=["0x[0-9]+"])
         self.expect("frame variable '*my_p'", substrs=["1"])

--- a/lldb/test/API/commands/frame/var-dil/basics/Indirection/TestFrameVarDILStrippedIndirection.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/Indirection/TestFrameVarDILStrippedIndirection.py
@@ -49,8 +49,8 @@ class TestFrameVarDILIndirection(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/InstanceVariables/TestFrameVarDILFullInstanceVariables.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/InstanceVariables/TestFrameVarDILFullInstanceVariables.py
@@ -49,15 +49,15 @@ class TestFrameVarDILInstanceVariables(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable 'this->field_'", substrs=["1"])
         self.expect("frame variable 'this.field_'", error=True,
                     substrs=["member reference type 'TestMethods *' is a pointer; did "

--- a/lldb/test/API/commands/frame/var-dil/basics/InstanceVariables/TestFrameVarDILStrippedInstanceVariables.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/InstanceVariables/TestFrameVarDILStrippedInstanceVariables.py
@@ -49,8 +49,8 @@ class TestFrameVarDILInstanceVariables(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILFullLocalVars.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILFullLocalVars.py
@@ -49,16 +49,15 @@ class TestFrameVarDILLocalVars(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        # Test 'a' is 1
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable a", substrs=["1"])
         self.expect("frame variable b", substrs=["2"])
         self.expect("frame variable c", substrs=["\\xfd"])

--- a/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILStrippedLocalVars.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILStrippedLocalVars.py
@@ -49,8 +49,8 @@ class TestFrameVarDILLocalVars(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOf/TestFrameVarDILFullMemberOf.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOf/TestFrameVarDILFullMemberOf.py
@@ -49,15 +49,15 @@ class TestFrameVarDILMemberOf(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable 's.x'", substrs=["1"])
         self.expect("frame variable 's.r'", substrs=["2"])
         self.expect("frame variable 's.r + 1'", substrs=["3"])

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOf/TestFrameVarDILStrippedMemberOf.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOf/TestFrameVarDILStrippedMemberOf.py
@@ -49,8 +49,8 @@ class TestFrameVarDILMemberOf(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOfAnonymousMember/TestFrameVarDILFullMemberOfAnonymousMember.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOfAnonymousMember/TestFrameVarDILFullMemberOfAnonymousMember.py
@@ -49,15 +49,15 @@ class TestFrameVarDILMemberOfAnonymousMember(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable 'a.x'", substrs=["1"])
         self.expect("frame variable 'a.y'", substrs=["2"])
 

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOfAnonymousMember/TestFrameVarDILStrippedMemberOfAnonymousMember.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOfAnonymousMember/TestFrameVarDILStrippedMemberOfAnonymousMember.py
@@ -49,8 +49,8 @@ class TestFrameVarDILMemberOfAnonymousMember(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOfInheritance/TestFrameVarDILFullMemberOfInheritance.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOfInheritance/TestFrameVarDILFullMemberOfInheritance.py
@@ -49,15 +49,15 @@ class TestFrameVarDILMemberOfInheritance(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable 'a.a_'", substrs=["1"])
         self.expect("frame variable 'b.b_'", substrs=["2"])
         self.expect("frame variable 'c.a_'", substrs=["1"])

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOfInheritance/TestFrameVarDILStrippedMemberOfInheritance.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOfInheritance/TestFrameVarDILStrippedMemberOfInheritance.py
@@ -49,8 +49,8 @@ class TestFrameVarDILMemberOfInheritance(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/PointerDereference/TestFrameVarDILFullPointerDereference.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/PointerDereference/TestFrameVarDILFullPointerDereference.py
@@ -49,8 +49,8 @@ class TestFrameVarDILPointerDereference(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
@@ -58,8 +58,8 @@ class TestFrameVarDILPointerDereference(TestBase):
 
         # Tests
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable '*p_int0'", substrs=["0"])
         self.expect("frame variable '*p_int0 + 1'", substrs=["1"])
         self.expect("frame variable '*cp_int5'", substrs=["5"])

--- a/lldb/test/API/commands/frame/var-dil/basics/PointerDereference/TestFrameVarDILStrippedPointerDereference.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/PointerDereference/TestFrameVarDILStrippedPointerDereference.py
@@ -49,8 +49,8 @@ class TestFrameVarDILPointerDereference(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILFullQualifiedId.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILFullQualifiedId.py
@@ -49,15 +49,15 @@ class TestFrameVarDILQualifiedId(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable '::ns::i'", substrs=["1"])
         self.expect("frame variable 'ns::i'", substrs=["1"])
         self.expect("frame variable '::ns::ns::i'", substrs=["2"])

--- a/lldb/test/API/commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILStrippedQualifiedId.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILStrippedQualifiedId.py
@@ -49,8 +49,8 @@ class TestFrameVarDILQualifiedId(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILFullSharedPtr.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILFullSharedPtr.py
@@ -49,8 +49,8 @@ class TestFrameVarDILSharedPtr(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILFullSharedPtrDeref.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILFullSharedPtrDeref.py
@@ -49,14 +49,12 @@ class TestFrameVarDILSharedPtrDeref(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
-
-
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILStrippedSharedPtr.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILStrippedSharedPtr.py
@@ -49,8 +49,8 @@ class TestFrameVarDILSharedPtr(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILStrippedSharedPtrDeref.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILStrippedSharedPtrDeref.py
@@ -49,8 +49,8 @@ class TestFrameVarDILSharedPtrDeref(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/Subscript/TestFrameVarDILFullSubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/Subscript/TestFrameVarDILFullSubscript.py
@@ -49,15 +49,15 @@ class TestFrameVarDILSubscript(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
 
         # const char*
         self.expect("frame variable 'char_ptr[0]'", substrs=["'l'"])

--- a/lldb/test/API/commands/frame/var-dil/basics/Subscript/TestFrameVarDILStrippedSubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/Subscript/TestFrameVarDILStrippedSubscript.py
@@ -49,8 +49,8 @@ class TestFrameVarDILSubscript(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILFullUniquePtr.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILFullUniquePtr.py
@@ -49,8 +49,8 @@ class TestFrameVarDILUniquePtr(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILFullUniquePtrDeref.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILFullUniquePtrDeref.py
@@ -49,15 +49,15 @@ class TestFrameVarDILUniquePtrDeref(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
 
         # Test member-of dereference.
         self.expect("frame variable 'ptr_node->value'", substrs=["1"])

--- a/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILStrippedUniquePtr.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILStrippedUniquePtr.py
@@ -49,8 +49,8 @@ class TestFrameVarDILUniquePtr(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILStrippedUniquePtrDeref.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILStrippedUniquePtrDeref.py
@@ -49,8 +49,8 @@ class TestFrameVarDILUniquePtrDeref(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/casting/CStyleCast/TestFrameVarDILFullCStyleCast.py
+++ b/lldb/test/API/commands/frame/var-dil/casting/CStyleCast/TestFrameVarDILFullCStyleCast.py
@@ -49,13 +49,15 @@ class TestFrameVarDILCStyleCast(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
+        self.expect("settings set target.experimental.use-DIL true",
+                  substrs=[""])
         # TestCStyleCastBUiltins
         #  self.expect("frame variable '(int)1'", IsOk[])
         #  self.expect("frame variable '(long long)1'", IsOk[])
@@ -95,35 +97,35 @@ class TestFrameVarDILCStyleCast(TestBase):
         self.expect("frame variable '(int)true'", substrs=["1"])
         self.expect("frame variable '(float)1'", substrs=["1"])
         self.expect("frame variable '(float)1.1'", substrs=["1.10000002"])
-#        self.expect("frame variable '(float)1.1f'", substrs=["1.10000002"])
+        self.expect("frame variable '(float)1.1f'", substrs=["1.10000002"])
         self.expect("frame variable '(float)-1.1'", substrs=["-1.10000002"])
-#        self.expect("frame variable '(float)-1.1f'", substrs=["-1.10000002"])
+        self.expect("frame variable '(float)-1.1f'", substrs=["-1.10000002"])
         self.expect("frame variable '(float)false'", substrs=["0"])
         self.expect("frame variable '(float)true'", substrs=["1"])
         self.expect("frame variable '(double)1'", substrs=["1"])
         self.expect("frame variable '(double)1.1'",
                     substrs=["1.1000000000000001"])
-#        self.expect("frame variable '(double)1.1f'",
-#                    substrs=["1.1000000238418579"])
+        self.expect("frame variable '(double)1.1f'",
+                    substrs=["1.1000000238418579"])
         self.expect("frame variable '(double)-1.1'",
                     substrs=["-1.1000000000000001"])
-#        self.expect("frame variable '(double)-1.1f'",
-#                    substrs=["-1.1000000238418579"])
+        self.expect("frame variable '(double)-1.1f'",
+                    substrs=["-1.1000000238418579"])
         self.expect("frame variable '(double)false'", substrs=["0"])
         self.expect("frame variable '(double)true'", substrs=["1"])
         self.expect("frame variable '(int)1.1'", substrs=["1"])
- #       self.expect("frame variable '(int)1.1f'", substrs=["1"])
+        self.expect("frame variable '(int)1.1f'", substrs=["1"])
         self.expect("frame variable '(int)-1.1'", substrs=["-1"])
         self.expect("frame variable '(long)1.1'", substrs=["1"])
- #       self.expect("frame variable '(long)-1.1f'", substrs=["-1"])
+        self.expect("frame variable '(long)-1.1f'", substrs=["-1"])
         self.expect("frame variable '(bool)0'", substrs=["false"])
         self.expect("frame variable '(bool)0.0'", substrs=["false"])
- #       self.expect("frame variable '(bool)0.0f'", substrs=["false"])
+        self.expect("frame variable '(bool)0.0f'", substrs=["false"])
         self.expect("frame variable '(bool)3'", substrs=["true"])
         self.expect("frame variable '(bool)-3'", substrs=["true"])
         self.expect("frame variable '(bool)-3.4'", substrs=["true"])
         self.expect("frame variable '(bool)-0.1'", substrs=["true"])
- #       self.expect("frame variable '(bool)-0.1f'", substrs=["true"])
+        self.expect("frame variable '(bool)-0.1f'", substrs=["true"])
 
         self.expect("frame variable '&(int)1'", error=True,
                     substrs=["cannot take the address of an rvalue of type"
@@ -154,7 +156,7 @@ class TestFrameVarDILCStyleCast(TestBase):
 
         # Test with typedefs and namespaces.
         self.expect("frame variable '(myint)1'", substrs=["1"])
-#        self.expect("frame variable '(myint)1LL'", substrs=["1"])
+        self.expect("frame variable '(myint)1LL'", substrs=["1"])
         self.expect("frame variable '(ns::myint)1'", substrs=["1"])
         self.expect("frame variable '(::ns::myint)1'", substrs=["1"])
         self.expect("frame variable '(::ns::myint)myint_'", substrs=["1"])
@@ -180,8 +182,8 @@ class TestFrameVarDILCStyleCast(TestBase):
         #  self.expect("frame variable '(unsigned long long)vp'", IsOk[])
         #  self.expect("frame variable '(long long)arr'", IsOk[])
         self.expect("frame variable '(bool)ap'", substrs=["true"])
-#        self.expect("frame variable '(bool)(int*)0x00000000'",
-#                    substrs=["false"])
+        self.expect("frame variable '(bool)(int*)0x00000000'",
+                    substrs=["false"])
         self.expect("frame variable '(bool)nullptr'", substrs=["false"])
         self.expect("frame variable '(bool)arr'", substrs=["true"])
         self.expect("frame variable '(char)ap'", error=True,
@@ -240,14 +242,14 @@ class TestFrameVarDILCStyleCast(TestBase):
                     substrs=["cannot cast from type 'double' to pointer type"
                              " 'char *'"])
 
-#        self.expect("frame variable '*(const int* const)ap'", substrs=["1"])
-#        self.expect("frame variable '*(volatile int* const)ap'", substrs=["1"])
-#        self.expect("frame variable '*(const int* const)vp'", substrs=["1"])
-#        self.expect("frame variable '*(const int* const volatile const)vp'",
-#                    substrs=["1"])
+        self.expect("frame variable '*(const int* const)ap'", substrs=["1"])
+        self.expect("frame variable '*(volatile int* const)ap'", substrs=["1"])
+        self.expect("frame variable '*(const int* const)vp'", substrs=["1"])
+        self.expect("frame variable '*(const int* const volatile const)vp'",
+                    substrs=["1"])
         self.expect("frame variable '*(int*)(void*)ap'", substrs=["1"])
-#        self.expect("frame variable '*(int*)(const void* const volatile)ap'",
-#                    substrs=["1"])
+        self.expect("frame variable '*(int*)(const void* const volatile)ap'",
+                    substrs=["1"])
 
         #  self.expect("frame variable '(ns::Foo*)ns_inner_foo_ptr_'", IsOk[])
         #  self.expect("frame variable '(ns::inner::Foo*)ns_foo_ptr_'", IsOk[])
@@ -318,7 +320,7 @@ class TestFrameVarDILCStyleCast(TestBase):
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
        # The hit count for the breakpoint should be 2.
-        self.assertEquals(breakpoint.GetHitCount(), 2)
+        self.assertEqual(breakpoint.GetHitCount(), 2)
 
         self.expect("frame variable '(int*)arr_1d'", patterns=["0x[0-9]+"])
         self.expect("frame variable '(char*)arr_1d'", patterns=["0x[0-9]+"])

--- a/lldb/test/API/commands/frame/var-dil/casting/CastInheritedTypes/TestFrameVarDILFullCastInheritedTypes.py
+++ b/lldb/test/API/commands/frame/var-dil/casting/CastInheritedTypes/TestFrameVarDILFullCastInheritedTypes.py
@@ -49,14 +49,16 @@ class TestFrameVarDILArithmetic(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        # TestCastDerivedToBase
+        self.expect("settings set target.experimental.use-DIL true",
+                   substrs=[""])
+       # TestCastDerivedToBase
 
         self.expect("frame variable 'static_cast<CxxA*>(&a)->a'",
                     substrs=["1"])

--- a/lldb/test/API/commands/frame/var-dil/casting/CxxCast/TestFrameVarDILFullCxxCast.py
+++ b/lldb/test/API/commands/frame/var-dil/casting/CxxCast/TestFrameVarDILFullCxxCast.py
@@ -49,13 +49,15 @@ class TestFrameVarDILArithmetic(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
+        self.expect("settings set target.experimental.use-DIL true",
+                  substrs=[""])
 
         # TestCxxStaticCast
 
@@ -96,7 +98,7 @@ class TestFrameVarDILArithmetic(TestBase):
         self.expect("frame variable 'static_cast<UEnum>(s_enum)'", substrs=["kUOne"])
         self.expect("frame variable 'static_cast<UEnum>(2.1)'", substrs=["kUTwo"])
         self.expect("frame variable 'static_cast<SEnum>(true)'", substrs=["kSOne"])
-#        self.expect("frame variable 'static_cast<SEnum>(0.4f)'", substrs=["kSZero"])
+        self.expect("frame variable 'static_cast<SEnum>(0.4f)'", substrs=["kSZero"])
         self.expect("frame variable 'static_cast<SEnum>(td_senum)'", substrs=["kSOne"])
         self.expect("frame variable 'static_cast<td_senum_t>(UEnum::kUOne)'", substrs=["kSOne"])
 
@@ -324,7 +326,7 @@ class TestFrameVarDILArithmetic(TestBase):
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
         # The hit count for the breakpoint should be 2.
-        self.assertEquals(breakpoint.GetHitCount(), 2)
+        self.assertEqual(breakpoint.GetHitCount(), 2)
 
         # LLDB doesn't support `dynamic_cast` in the expression evaluator.
         ##this->compare_with_lldb_ = false;

--- a/lldb/test/API/commands/frame/var-dil/math_exprs/Arithmetic/TestFrameVarDILFullArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/math_exprs/Arithmetic/TestFrameVarDILFullArithmetic.py
@@ -49,15 +49,15 @@ class TestFrameVarDILArithmetic(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 
-        #self.expect("settings set target.experimental.use-DIL true",
-        #            substrs=[""])
+        self.expect("settings set target.experimental.use-DIL true",
+                    substrs=[""])
         self.expect("frame variable a", substrs=["1"])
         self.expect("frame variable 'a + c'", substrs=["11"])
 
@@ -81,7 +81,7 @@ class TestFrameVarDILArithmetic(TestBase):
                     substrs=["4294967295"])
         self.expect("frame variable '4294967295 + 1'",
                     substrs=["4294967296"])
-#        self.expect("frame variable '4294967295U + 1'", substrs=["0"])
+        self.expect("frame variable '4294967295U + 1'", substrs=["0"])
 
         # Note: Signed overflow is UB.
         self.expect("frame variable 'll_max + 1'",
@@ -98,10 +98,10 @@ class TestFrameVarDILArithmetic(TestBase):
                     substrs=["18446744073709551615"])
         self.expect("frame variable '9223372036854775807 + 1'",
                     substrs=["-9223372036854775808"])
-#        self.expect("frame variable '9223372036854775807LL + 1'",
-#                    substrs=["-9223372036854775808"])
-#        self.expect("frame variable '18446744073709551615ULL + 1'",
-#                    substrs=["0"])
+        self.expect("frame variable '9223372036854775807LL + 1'",
+                    substrs=["-9223372036854775808"])
+        self.expect("frame variable '18446744073709551615ULL + 1'",
+                    substrs=["0"])
 
         # Integer literal is too large to be represented in a signed integer
         # type, interpreting as unsigned.
@@ -111,16 +111,16 @@ class TestFrameVarDILArithmetic(TestBase):
                     substrs=["9223372036854775807"])
         self.expect("frame variable -- '-9223372036854775808 + 1'",
                     substrs=["9223372036854775809"])
-#        self.expect("frame variable -- '-9223372036854775808LL / -1'",
-#                    substrs=["0"])
-#        self.expect("frame variable -- '-9223372036854775808LL % -1'",
-#                    substrs=["9223372036854775808"])
+        self.expect("frame variable -- '-9223372036854775808LL / -1'",
+                    substrs=["0"])
+        self.expect("frame variable -- '-9223372036854775808LL % -1'",
+                    substrs=["9223372036854775808"])
 
-#        self.expect("frame variable -- '-20 / 1U'",
-#                    substrs=["4294967276"])
-#        self.expect("frame variable -- '-20LL / 1U'", substrs=["-20"])
-#        self.expect("frame variable -- '-20LL / 1ULL'",
-#                    substrs=["18446744073709551596"])
+        self.expect("frame variable -- '-20 / 1U'",
+                    substrs=["4294967276"])
+        self.expect("frame variable -- '-20LL / 1U'", substrs=["-20"])
+        self.expect("frame variable -- '-20LL / 1ULL'",
+                    substrs=["18446744073709551596"])
 
         # Unary arithmetic.
         self.expect("frame variable '+0'", substrs=["0"])
@@ -146,16 +146,16 @@ class TestFrameVarDILArithmetic(TestBase):
         self.expect("frame variable '1 / -0.0'", substrs=["-Inf"])
         self.expect("frame variable '+0.0 / +0.0  != +0.0 / +0.0'",
                     substrs=["true"])
-#        self.expect("frame variable -- '-1.f * 0'", substrs=["-0"])
-#        self.expect("frame variable '0x0.123p-1'",
-#                    substrs=["0.0355224609375"])
+        self.expect("frame variable -- '-1.f * 0'", substrs=["-0"])
+        self.expect("frame variable '0x0.123p-1'",
+                    substrs=["0.0355224609375"])
 
-#        self.expect("frame variable 'fnan < fnan'", substrs=["false"])
-#        self.expect("frame variable 'fnan == fnan'", substrs=["false"])
+        self.expect("frame variable 'fnan < fnan'", substrs=["false"])
+        self.expect("frame variable 'fnan == fnan'", substrs=["false"])
         self.expect("frame variable '(unsigned int) fdenorm'",
                     substrs=["0"])
-#        self.expect("frame variable '(unsigned int) (1.0f + fdenorm)'",
-#                    substrs=["1"])
+        self.expect("frame variable '(unsigned int) (1.0f + fdenorm)'",
+                    substrs=["1"])
 
         # Invalid remainder.
         self.expect("frame variable '1.1 % 2'", error=True,
@@ -164,9 +164,9 @@ class TestFrameVarDILArithmetic(TestBase):
 
         #  References and typedefs.
         self.expect("frame variable 'r + 1'", substrs=["3"])
-#        self.expect("frame variable 'r - 1l'", substrs=["1"])
-#        self.expect("frame variable 'r * 2u'", substrs=["4"])
-#        self.expect("frame variable 'r / 2ull'", substrs=["1"])
+        self.expect("frame variable 'r - 1l'", substrs=["1"])
+        self.expect("frame variable 'r * 2u'", substrs=["4"])
+        self.expect("frame variable 'r / 2ull'", substrs=["1"])
         self.expect("frame variable 'my_r + 1'", substrs=["3"])
         self.expect("frame variable 'my_r - 1'", substrs=["1"])
         self.expect("frame variable 'my_r * 2'", substrs=["4"])

--- a/lldb/test/API/commands/frame/var-dil/math_exprs/Assignment/TestFrameVarDILFullAssignment.py
+++ b/lldb/test/API/commands/frame/var-dil/math_exprs/Assignment/TestFrameVarDILFullAssignment.py
@@ -49,8 +49,8 @@ class TestFrameVarDILAssignment(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/frame/var-dil/math_exprs/Assignment/TestFrameVarDILStrippedAssignment.py
+++ b/lldb/test/API/commands/frame/var-dil/math_exprs/Assignment/TestFrameVarDILStrippedAssignment.py
@@ -49,8 +49,8 @@ class TestFrameVarDILAssignment(TestBase):
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at our breakpoint"
         )
-       # The hit count for the breakpoint should be 1.
-        self.assertEquals(breakpoint.GetHitCount(), 1)
+        # The hit count for the breakpoint should be 1.
+        self.assertEqual(breakpoint.GetHitCount(), 1)
 
         frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()


### PR DESCRIPTION
Make some needed changes to the Python DIL tests:
- Change 'self.assertEquals' calls to 'self.assertEqual' (remove ending 's'). This used to work, but it has started breaking.
- Also uncomment   self.expect("settings set target.experimental.use-DIL true",...) statements.
- Remove some dead code.