### PR TITLE
Apply all the changes from upstream review comments on other DIL PRs.

### DIFF
--- a/lldb/docs/dil-expr-lang.ebnf
+++ b/lldb/docs/dil-expr-lang.ebnf
@@ -75,7 +75,6 @@ primary_expression = numeric_literal
                    | boolean_literal
                    | pointer_literal
                    | id_expression
-                   | "this"
                    | "(" expression ")"
                    | builtin_func ;
 

--- a/lldb/include/lldb/ValueObject/DILAST.h
+++ b/lldb/include/lldb/ValueObject/DILAST.h
@@ -9,12 +9,6 @@
 #ifndef LLDB_VALUEOBJECT_DILAST_H
 #define LLDB_VALUEOBJECT_DILAST_H
 
-#include <memory>
-#include <optional>
-#include <string>
-#include <variant>
-#include <vector>
-
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Target/LanguageRuntime.h"
@@ -24,26 +18,13 @@
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/Support/Casting.h"
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
 
 namespace lldb_private::dil {
-
-/// Struct to hold information about member fields. Used by the parser for the
-/// Data Inspection Language (DIL).
-struct MemberInfo {
-  std::optional<std::string> name;
-  CompilerType type;
-  std::optional<uint32_t> bitfield_size_in_bits;
-  bool is_synthetic;
-  bool is_dynamic;
-  lldb::ValueObjectSP val_obj_sp;
-};
-
-/// Get the appropriate ValueObjectSP, consulting the use_dynamic and
-/// use_synthetic options passed.
-lldb::ValueObjectSP
-GetDynamicOrSyntheticValue(lldb::ValueObjectSP valobj_sp,
-                           lldb::DynamicValueType use_dynamic = lldb::eNoDynamicValues,
-                           bool use_synthetic = false);
 
 /// The various types DIL AST nodes (used by the DIL parser).
 enum class NodeKind {
@@ -167,12 +148,6 @@ public:
         new IdentifierInfo(Kind::eValue, type, valobj.GetSP(), {}));
   }
 
-  static std::unique_ptr<IdentifierInfo> FromContextArg(CompilerType type) {
-    lldb::ValueObjectSP empty_value;
-    return std::unique_ptr<IdentifierInfo>(
-        new IdentifierInfo(Kind::eContextArg, type, empty_value, {}));
-  }
-
   static std::unique_ptr<IdentifierInfo>
   FromMemberPath(CompilerType type, std::vector<uint32_t> path) {
     lldb::ValueObjectSP empty_value;
@@ -184,7 +159,6 @@ public:
   lldb::ValueObjectSP GetValue() const { return m_value; }
   const std::vector<uint32_t> &GetPath() const { return m_path; }
 
-  CompilerType GetType() { return m_type; }
   bool IsValid() const { return m_type.IsValid(); }
 
   IdentifierInfo(Kind kind, CompilerType type, lldb::ValueObjectSP value,
@@ -198,14 +172,6 @@ private:
   lldb::ValueObjectSP m_value;
   std::vector<uint32_t> m_path;
 };
-
-/// Given the name of an identifier (variable name, member name, type name,
-/// etc.), find the ValueObject for that name (if it exists) and create and
-/// return an IdentifierInfo object containing all the relevant information
-/// about that object (for DIL parsing and evaluating).
-std::unique_ptr<IdentifierInfo> LookupIdentifier(
-    const std::string &name, std::shared_ptr<ExecutionContextScope> ctx_scope,
-    lldb::DynamicValueType use_dynamic, CompilerType *scope_ptr = nullptr);
 
 /// Forward declaration, for use in DIL AST nodes. Definition is at the very
 /// end of this file.
@@ -221,17 +187,17 @@ class Visitor;
 /// Base class for AST nodes used by the Data Inspection Language (DIL) parser.
 /// All of the specialized types of AST nodes inherit from this (virtual) base
 /// class.
-class DILASTNode {
+class ASTNode {
 public:
-  DILASTNode(uint32_t location, NodeKind kind) :
-      m_location(location), m_kind(kind) {}
-  virtual ~DILASTNode() = default;
+  ASTNode(uint32_t location, NodeKind kind)
+      : m_location(location), m_kind(kind) {}
+  virtual ~ASTNode() = default;
 
-  virtual void Accept(Visitor *v) const = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const = 0;
 
-  virtual bool is_rvalue() const = 0;
-  virtual bool is_bitfield() const { return false; };
-  virtual bool is_context_var() const { return false; };
+  virtual bool is_rvalue() const { return false; }
+  virtual bool is_bitfield() const { return false; }
+  virtual bool is_context_var() const { return false; }
   virtual bool is_literal_zero() const { return false; }
   virtual uint32_t bitfield_size() const { return 0; }
   virtual CompilerType result_type() const = 0;
@@ -250,34 +216,29 @@ private:
   const NodeKind m_kind;
 };
 
-using DILASTNodeUP = std::unique_ptr<DILASTNode>;
+using ASTNodeUP = std::unique_ptr<ASTNode>;
 
-class ErrorNode : public DILASTNode {
+class ErrorNode : public ASTNode {
 public:
-  ErrorNode(CompilerType empty_type)
-      : DILASTNode(0, NodeKind::eErrorNode),
-        m_empty_type(empty_type) {}
-  void Accept(Visitor *v) const override;
-  bool is_rvalue() const override { return false; }
-  CompilerType result_type() const override { return m_empty_type; }
-  CompilerType result_type_real() const { return m_empty_type; }
-
-  static bool classof(const DILASTNode *node) {
-    return node->GetKind() == NodeKind::eErrorNode;
+  ErrorNode() : ASTNode(0, NodeKind::eErrorNode) {}
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
+  CompilerType result_type() const override {
+    CompilerType bad_type;
+    return bad_type;
   }
 
-private:
-  CompilerType m_empty_type;
+  static bool classof(const ASTNode *node) {
+    return node->GetKind() == NodeKind::eErrorNode;
+  }
 };
 
-class ScalarLiteralNode : public DILASTNode {
+class ScalarLiteralNode : public ASTNode {
 public:
-  ScalarLiteralNode(uint32_t location, CompilerType type,
-                    Scalar value)
-      : DILASTNode(location, NodeKind::eScalarLiteralNode), m_type(type),
+  ScalarLiteralNode(uint32_t location, CompilerType type, Scalar value)
+      : ASTNode(location, NodeKind::eScalarLiteralNode), m_type(type),
         m_value(value) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return true; }
   bool is_literal_zero() const override {
     return m_value.IsZero() && !m_type.IsBoolean();
@@ -286,7 +247,7 @@ public:
 
   Scalar GetValue() const & { return m_value; }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eScalarLiteralNode;
   }
 
@@ -295,21 +256,19 @@ private:
   Scalar m_value;
 };
 
-class StringLiteralNode : public DILASTNode {
+class StringLiteralNode : public ASTNode {
 public:
-  StringLiteralNode(uint32_t location, CompilerType type,
-                    std::string value)
-      : DILASTNode(location, NodeKind::eStringLiteralNode),
-        m_type(type),
+  StringLiteralNode(uint32_t location, CompilerType type, std::string value)
+      : ASTNode(location, NodeKind::eStringLiteralNode), m_type(type),
         m_value(value) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return true; }
   CompilerType result_type() const override { return m_type; }
 
   std::string GetValue() const & { return m_value; }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eStringLiteralNode;
   }
 
@@ -318,28 +277,31 @@ private:
   std::string m_value;
 };
 
-class IdentifierNode : public DILASTNode {
+class IdentifierNode : public ASTNode {
 public:
   IdentifierNode(uint32_t location, std::string name,
+                 lldb::DynamicValueType use_dynamic,
                  std::unique_ptr<IdentifierInfo> identifier, bool is_rvalue,
                  bool is_context_var)
-      : DILASTNode(location, NodeKind::eIdentifierNode),
-        m_is_rvalue(is_rvalue),
+      : ASTNode(location, NodeKind::eIdentifierNode), m_is_rvalue(is_rvalue),
         m_is_context_var(is_context_var), m_name(std::move(name)),
-        m_identifier(std::move(identifier)) {}
+        m_identifier(std::move(identifier)), m_use_dynamic(use_dynamic) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return m_is_rvalue; }
   bool is_context_var() const override { return m_is_context_var; };
-  CompilerType result_type() const override { return m_identifier->GetType(); }
+  CompilerType result_type() const override {
+    return m_identifier->GetValue()->GetCompilerType();
+  }
   ValueObject *valobj() const override {
     return m_identifier->GetValue().get();
   }
 
-  std::string name() const { return m_name; }
+  lldb::DynamicValueType GetUseDynamic() const { return m_use_dynamic; }
+  std::string GetName() const { return m_name; }
   const IdentifierInfo &info() const { return *m_identifier; }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eIdentifierNode;
   }
 
@@ -348,22 +310,22 @@ private:
   bool m_is_context_var;
   std::string m_name;
   std::unique_ptr<IdentifierInfo> m_identifier;
+  lldb::DynamicValueType m_use_dynamic;
 };
 
-class SizeOfNode : public DILASTNode {
+class SizeOfNode : public ASTNode {
 public:
-  SizeOfNode(uint32_t location, CompilerType type,
-             CompilerType operand)
-      : DILASTNode(location, NodeKind::eSizeOfNode),
-        m_type(type), m_operand(operand) {}
+  SizeOfNode(uint32_t location, CompilerType type, CompilerType operand)
+      : ASTNode(location, NodeKind::eSizeOfNode), m_type(type),
+        m_operand(operand) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return true; }
   CompilerType result_type() const override { return m_type; }
 
   CompilerType operand() const { return m_operand; }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eSizeOfNode;
   }
 
@@ -372,47 +334,48 @@ private:
   CompilerType m_operand;
 };
 
-class BuiltinFunctionCallNode : public DILASTNode {
+class BuiltinFunctionCallNode : public ASTNode {
 public:
-  BuiltinFunctionCallNode(uint32_t location,
-                          CompilerType result_type, std::string name,
-                          std::vector<DILASTNodeUP> arguments)
-      : DILASTNode(location, NodeKind::eBuiltinFunctionCallNode),
-        m_result_type(result_type),
-        m_name(std::move(name)), m_arguments(std::move(arguments)) {}
+  BuiltinFunctionCallNode(uint32_t location, CompilerType result_type,
+                          std::string name, std::vector<ASTNodeUP> arguments)
+      : ASTNode(location, NodeKind::eBuiltinFunctionCallNode),
+        m_result_type(result_type), m_name(std::move(name)),
+        m_arguments(std::move(arguments)) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return true; }
   CompilerType result_type() const override { return m_result_type; }
 
   std::string name() const { return m_name; }
-  const std::vector<DILASTNodeUP> &arguments() const { return m_arguments; };
+  const std::vector<ASTNodeUP> &arguments() const { return m_arguments; };
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eBuiltinFunctionCallNode;
   }
 
 private:
   CompilerType m_result_type;
   std::string m_name;
-  std::vector<DILASTNodeUP> m_arguments;
+  std::vector<ASTNodeUP> m_arguments;
 };
 
-class CStyleCastNode : public DILASTNode {
+class CStyleCastNode : public ASTNode {
 public:
-  CStyleCastNode(uint32_t location, CompilerType type,
-                 DILASTNodeUP operand, CStyleCastKind kind)
-      : DILASTNode(location, NodeKind::eCStyleCastNode),
-        m_type(type), m_operand(std::move(operand)),
-        m_cast_kind(kind) { m_promo_kind = TypePromotionCastKind::eNone; }
+  CStyleCastNode(uint32_t location, CompilerType type, ASTNodeUP operand,
+                 CStyleCastKind kind)
+      : ASTNode(location, NodeKind::eCStyleCastNode), m_type(type),
+        m_operand(std::move(operand)), m_cast_kind(kind) {
+    m_promo_kind = TypePromotionCastKind::eNone;
+  }
 
-  CStyleCastNode(uint32_t location, CompilerType type,
-                 DILASTNodeUP operand, TypePromotionCastKind kind)
-      : DILASTNode(location, NodeKind::eCStyleCastNode),
-        m_type(type), m_operand(std::move(operand)),
-        m_promo_kind(kind) { m_cast_kind = CStyleCastKind::eNone; }
+  CStyleCastNode(uint32_t location, CompilerType type, ASTNodeUP operand,
+                 TypePromotionCastKind kind)
+      : ASTNode(location, NodeKind::eCStyleCastNode), m_type(type),
+        m_operand(std::move(operand)), m_promo_kind(kind) {
+    m_cast_kind = CStyleCastKind::eNone;
+  }
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override {
     return m_cast_kind != CStyleCastKind::eReference;
   }
@@ -420,28 +383,27 @@ public:
   ValueObject *valobj() const override { return m_operand->valobj(); }
 
   CompilerType type() const { return m_type; }
-  DILASTNode *operand() const { return m_operand.get(); }
+  ASTNode *operand() const { return m_operand.get(); }
   CStyleCastKind cast_kind() const { return m_cast_kind; }
   TypePromotionCastKind promo_kind() const { return m_promo_kind; }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eCStyleCastNode;
   }
 
 private:
   CompilerType m_type;
-  DILASTNodeUP m_operand;
+  ASTNodeUP m_operand;
   CStyleCastKind m_cast_kind;
   TypePromotionCastKind m_promo_kind;
 };
 
-class CxxStaticCastNode : public DILASTNode {
+class CxxStaticCastNode : public ASTNode {
 public:
-  CxxStaticCastNode(uint32_t location, CompilerType type,
-                    DILASTNodeUP operand, CxxStaticCastKind kind,
-                    bool is_rvalue)
-      : DILASTNode(location, NodeKind::eCxxStaticCastNode),
-        m_type(type), m_operand(std::move(operand)), m_cast_kind(kind),
+  CxxStaticCastNode(uint32_t location, CompilerType type, ASTNodeUP operand,
+                    CxxStaticCastKind kind, bool is_rvalue)
+      : ASTNode(location, NodeKind::eCxxStaticCastNode), m_type(type),
+        m_operand(std::move(operand)), m_cast_kind(kind),
         m_is_rvalue(is_rvalue) {
     assert(kind != CxxStaticCastKind::eBaseToDerived &&
            kind != CxxStaticCastKind::eDerivedToBase &&
@@ -449,53 +411,49 @@ public:
     m_promo_kind = TypePromotionCastKind::eNone;
   }
 
-  CxxStaticCastNode(uint32_t location, CompilerType type,
-                    DILASTNodeUP operand, TypePromotionCastKind kind,
-                    bool is_rvalue)
-      : DILASTNode(location, NodeKind::eCxxStaticCastNode),
-        m_type(type), m_operand(std::move(operand)), m_promo_kind(kind),
+  CxxStaticCastNode(uint32_t location, CompilerType type, ASTNodeUP operand,
+                    TypePromotionCastKind kind, bool is_rvalue)
+      : ASTNode(location, NodeKind::eCxxStaticCastNode), m_type(type),
+        m_operand(std::move(operand)), m_promo_kind(kind),
         m_is_rvalue(is_rvalue) {
     m_cast_kind = CxxStaticCastKind::eNone;
   }
 
-  CxxStaticCastNode(uint32_t location, CompilerType type,
-                    DILASTNodeUP operand, std::vector<uint32_t> idx,
-                    bool is_rvalue)
-      : DILASTNode(location, NodeKind::eCxxStaticCastNode),
-        m_type(type), m_operand(std::move(operand)),
-        m_idx(std::move(idx)), m_cast_kind(CxxStaticCastKind::eDerivedToBase),
-        m_is_rvalue(is_rvalue) {
+  CxxStaticCastNode(uint32_t location, CompilerType type, ASTNodeUP operand,
+                    std::vector<uint32_t> idx, bool is_rvalue)
+      : ASTNode(location, NodeKind::eCxxStaticCastNode), m_type(type),
+        m_operand(std::move(operand)), m_idx(std::move(idx)),
+        m_cast_kind(CxxStaticCastKind::eDerivedToBase), m_is_rvalue(is_rvalue) {
     m_promo_kind = TypePromotionCastKind::eNone;
   }
 
-  CxxStaticCastNode(uint32_t location, CompilerType type,
-                    DILASTNodeUP operand, uint64_t offset, bool is_rvalue)
-      : DILASTNode(location, NodeKind::eCxxStaticCastNode),
-        m_type(type), m_operand(std::move(operand)),
-        m_offset(offset), m_cast_kind(CxxStaticCastKind::eBaseToDerived),
-        m_is_rvalue(is_rvalue) {
+  CxxStaticCastNode(uint32_t location, CompilerType type, ASTNodeUP operand,
+                    uint64_t offset, bool is_rvalue)
+      : ASTNode(location, NodeKind::eCxxStaticCastNode), m_type(type),
+        m_operand(std::move(operand)), m_offset(offset),
+        m_cast_kind(CxxStaticCastKind::eBaseToDerived), m_is_rvalue(is_rvalue) {
     m_promo_kind = TypePromotionCastKind::eNone;
   }
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return m_is_rvalue; }
   CompilerType result_type() const override { return m_type; }
   ValueObject *valobj() const override { return m_operand->valobj(); }
 
   CompilerType type() const { return m_type; }
-  DILASTNode *operand() const { return m_operand.get(); }
+  ASTNode *operand() const { return m_operand.get(); }
   const std::vector<uint32_t> &idx() const { return m_idx; }
   uint64_t offset() const { return m_offset; }
   CxxStaticCastKind cast_kind() const { return m_cast_kind; }
   TypePromotionCastKind promo_kind() const { return m_promo_kind; }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eCxxStaticCastNode;
   }
 
 private:
   CompilerType m_type;
-  DILASTNodeUP m_operand;
+  ASTNodeUP m_operand;
   std::vector<uint32_t> m_idx;
   uint64_t m_offset = 0;
   CxxStaticCastKind m_cast_kind;
@@ -503,47 +461,45 @@ private:
   bool m_is_rvalue;
 };
 
-class CxxReinterpretCastNode : public DILASTNode {
+class CxxReinterpretCastNode : public ASTNode {
 public:
   CxxReinterpretCastNode(uint32_t location, CompilerType type,
-                         DILASTNodeUP operand, bool is_rvalue)
-      : DILASTNode(location, NodeKind::eCxxReinterpretCastNode),
-        m_type(type), m_operand(std::move(operand)),
-        m_is_rvalue(is_rvalue) {}
+                         ASTNodeUP operand, bool is_rvalue)
+      : ASTNode(location, NodeKind::eCxxReinterpretCastNode), m_type(type),
+        m_operand(std::move(operand)), m_is_rvalue(is_rvalue) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return m_is_rvalue; }
   CompilerType result_type() const override { return m_type; }
   ValueObject *valobj() const override { return m_operand->valobj(); }
 
   CompilerType type() const { return m_type; }
-  DILASTNode *operand() const { return m_operand.get(); }
+  ASTNode *operand() const { return m_operand.get(); }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eCxxReinterpretCastNode;
   }
 
 private:
   CompilerType m_type;
-  DILASTNodeUP m_operand;
+  ASTNodeUP m_operand;
   bool m_is_rvalue;
 };
 
-class MemberOfNode : public DILASTNode {
+class MemberOfNode : public ASTNode {
 public:
-  MemberOfNode(uint32_t location, CompilerType result_type,
-               DILASTNodeUP base, std::optional<uint32_t> bitfield_size,
+  MemberOfNode(uint32_t location, CompilerType result_type, ASTNodeUP base,
+               std::optional<uint32_t> bitfield_size,
                std::vector<uint32_t> member_index, bool is_arrow,
                bool is_synthetic, bool is_dynamic, ConstString name,
                lldb::ValueObjectSP field_valobj_sp)
-      : DILASTNode(location, NodeKind::eMemberOfNode),
-        m_result_type(result_type), m_base(std::move(base)),
-        m_bitfield_size(bitfield_size), m_member_index(std::move(member_index)),
-        m_is_arrow(is_arrow), m_is_synthetic(is_synthetic),
-        m_is_dynamic(is_dynamic), m_field_name(name),
-        m_field_valobj_sp(field_valobj_sp) {}
+      : ASTNode(location, NodeKind::eMemberOfNode), m_result_type(result_type),
+        m_base(std::move(base)), m_bitfield_size(bitfield_size),
+        m_member_index(std::move(member_index)), m_is_arrow(is_arrow),
+        m_is_synthetic(is_synthetic), m_is_dynamic(is_dynamic),
+        m_field_name(name), m_field_valobj_sp(field_valobj_sp) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return false; }
   bool is_bitfield() const override { return m_bitfield_size ? true : false; }
   uint32_t bitfield_size() const override {
@@ -552,20 +508,20 @@ public:
   CompilerType result_type() const override { return m_result_type; }
   ValueObject *valobj() const override { return m_field_valobj_sp.get(); }
 
-  DILASTNode *base() const { return m_base.get(); }
+  ASTNode *base() const { return m_base.get(); }
   const std::vector<uint32_t> &member_index() const { return m_member_index; }
   bool is_arrow() const { return m_is_arrow; }
   bool is_synthetic() const { return m_is_synthetic; }
   bool is_dynamic() const { return m_is_dynamic; }
   ConstString field_name() const { return m_field_name; }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eMemberOfNode;
   }
 
 private:
   CompilerType m_result_type;
-  DILASTNodeUP m_base;
+  ASTNodeUP m_base;
   std::optional<uint32_t> m_bitfield_size;
   std::vector<uint32_t> m_member_index;
   bool m_is_arrow;
@@ -575,15 +531,15 @@ private:
   lldb::ValueObjectSP m_field_valobj_sp;
 };
 
-class ArraySubscriptNode : public DILASTNode {
+class ArraySubscriptNode : public ASTNode {
 public:
   ArraySubscriptNode(uint32_t location, CompilerType result_type,
-                     DILASTNodeUP base, DILASTNodeUP index)
-      : DILASTNode(location, NodeKind::eArraySubscriptNode),
-        m_result_type(result_type),
-        m_base(std::move(base)), m_index(std::move(index)) {}
+                     ASTNodeUP base, ASTNodeUP index)
+      : ASTNode(location, NodeKind::eArraySubscriptNode),
+        m_result_type(result_type), m_base(std::move(base)),
+        m_index(std::move(index)) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return false; }
   CompilerType result_type() const override { return m_result_type; }
   ValueObject *valobj() const override {
@@ -600,34 +556,32 @@ public:
     return base_obj;
   }
 
-  DILASTNode *base() const { return m_base.get(); }
-  DILASTNode *index() const { return m_index.get(); }
+  ASTNode *base() const { return m_base.get(); }
+  ASTNode *index() const { return m_index.get(); }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eArraySubscriptNode;
   }
 
 private:
   CompilerType m_result_type;
-  DILASTNodeUP m_base;
-  DILASTNodeUP m_index;
+  ASTNodeUP m_base;
+  ASTNodeUP m_index;
 };
 
-class BinaryOpNode : public DILASTNode {
+class BinaryOpNode : public ASTNode {
 public:
-  BinaryOpNode(uint32_t location, CompilerType result_type,
-               BinaryOpKind kind, DILASTNodeUP lhs, DILASTNodeUP rhs,
-               CompilerType comp_assign_type,
+  BinaryOpNode(uint32_t location, CompilerType result_type, BinaryOpKind kind,
+               ASTNodeUP lhs, ASTNodeUP rhs, CompilerType comp_assign_type,
                ValueObject *val_obj_ptr = nullptr)
-      : DILASTNode(location, NodeKind::eBinaryOpNode),
-        m_result_type(result_type), m_kind(kind),
-        m_lhs(std::move(lhs)), m_rhs(std::move(rhs)),
+      : ASTNode(location, NodeKind::eBinaryOpNode), m_result_type(result_type),
+        m_kind(kind), m_lhs(std::move(lhs)), m_rhs(std::move(rhs)),
         m_comp_assign_type(comp_assign_type) {
-      if (val_obj_ptr)
+    if (val_obj_ptr)
       m_val_obj_sp = val_obj_ptr->GetSP();
   }
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override {
     return !binary_op_kind_is_comp_assign(m_kind);
   }
@@ -645,58 +599,56 @@ public:
   }
 
   BinaryOpKind kind() const { return m_kind; }
-  DILASTNode *lhs() const { return m_lhs.get(); }
-  DILASTNode *rhs() const { return m_rhs.get(); }
+  ASTNode *lhs() const { return m_lhs.get(); }
+  ASTNode *rhs() const { return m_rhs.get(); }
   CompilerType comp_assign_type() const { return m_comp_assign_type; }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eBinaryOpNode;
   }
 
 private:
   CompilerType m_result_type;
   BinaryOpKind m_kind;
-  DILASTNodeUP m_lhs;
-  DILASTNodeUP m_rhs;
+  ASTNodeUP m_lhs;
+  ASTNodeUP m_rhs;
   CompilerType m_comp_assign_type;
   lldb::ValueObjectSP m_val_obj_sp;
 };
 
-class UnaryOpNode : public DILASTNode {
+class UnaryOpNode : public ASTNode {
 public:
-  UnaryOpNode(uint32_t location, CompilerType result_type,
-              UnaryOpKind kind, DILASTNodeUP rhs)
-      : DILASTNode(location, NodeKind::eUnaryOpNode),
-        m_result_type(result_type), m_kind(kind),
-        m_rhs(std::move(rhs)) {}
+  UnaryOpNode(uint32_t location, CompilerType result_type, UnaryOpKind kind,
+              ASTNodeUP rhs)
+      : ASTNode(location, NodeKind::eUnaryOpNode), m_result_type(result_type),
+        m_kind(kind), m_rhs(std::move(rhs)) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return m_kind != UnaryOpKind::Deref; }
   CompilerType result_type() const override { return m_result_type; }
   ValueObject *valobj() const override { return m_rhs->valobj(); }
 
   UnaryOpKind kind() const { return m_kind; }
-  DILASTNode *rhs() const { return m_rhs.get(); }
+  ASTNode *rhs() const { return m_rhs.get(); }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eUnaryOpNode;
   }
 
 private:
   CompilerType m_result_type;
   UnaryOpKind m_kind;
-  DILASTNodeUP m_rhs;
+  ASTNodeUP m_rhs;
 };
 
-class TernaryOpNode : public DILASTNode {
+class TernaryOpNode : public ASTNode {
 public:
-  TernaryOpNode(uint32_t location, CompilerType result_type,
-                DILASTNodeUP cond, DILASTNodeUP lhs, DILASTNodeUP rhs)
-      : DILASTNode(location, NodeKind::eTernaryOpNode),
-        m_result_type(result_type),
+  TernaryOpNode(uint32_t location, CompilerType result_type, ASTNodeUP cond,
+                ASTNodeUP lhs, ASTNodeUP rhs)
+      : ASTNode(location, NodeKind::eTernaryOpNode), m_result_type(result_type),
         m_cond(std::move(cond)), m_lhs(std::move(lhs)), m_rhs(std::move(rhs)) {}
 
-  void Accept(Visitor *v) const override;
+  llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override {
     return m_lhs->is_rvalue() || m_rhs->is_rvalue();
   }
@@ -705,19 +657,19 @@ public:
   }
   CompilerType result_type() const override { return m_result_type; }
 
-  DILASTNode *cond() const { return m_cond.get(); }
-  DILASTNode *lhs() const { return m_lhs.get(); }
-  DILASTNode *rhs() const { return m_rhs.get(); }
+  ASTNode *cond() const { return m_cond.get(); }
+  ASTNode *lhs() const { return m_lhs.get(); }
+  ASTNode *rhs() const { return m_rhs.get(); }
 
-  static bool classof(const DILASTNode *node) {
+  static bool classof(const ASTNode *node) {
     return node->GetKind() == NodeKind::eTernaryOpNode;
   }
 
 private:
   CompilerType m_result_type;
-  DILASTNodeUP m_cond;
-  DILASTNodeUP m_lhs;
-  DILASTNodeUP m_rhs;
+  ASTNodeUP m_cond;
+  ASTNodeUP m_lhs;
+  ASTNodeUP m_rhs;
 };
 
 /// This class contains one Visit method for each specialized type of
@@ -727,20 +679,31 @@ private:
 class Visitor {
 public:
   virtual ~Visitor() = default;
-  virtual void Visit(const ErrorNode *node) = 0;
-  virtual void Visit(const ScalarLiteralNode *node) = 0;
-  virtual void Visit(const StringLiteralNode *node) = 0;
-  virtual void Visit(const IdentifierNode *node) = 0;
-  virtual void Visit(const SizeOfNode *node) = 0;
-  virtual void Visit(const BuiltinFunctionCallNode *node) = 0;
-  virtual void Visit(const CStyleCastNode *node) = 0;
-  virtual void Visit(const CxxStaticCastNode *node) = 0;
-  virtual void Visit(const CxxReinterpretCastNode *node) = 0;
-  virtual void Visit(const MemberOfNode *node) = 0;
-  virtual void Visit(const ArraySubscriptNode *node) = 0;
-  virtual void Visit(const BinaryOpNode *node) = 0;
-  virtual void Visit(const UnaryOpNode *node) = 0;
-  virtual void Visit(const TernaryOpNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const ScalarLiteralNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const StringLiteralNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const IdentifierNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP> Visit(const SizeOfNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const BuiltinFunctionCallNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const CStyleCastNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const CxxStaticCastNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const CxxReinterpretCastNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const MemberOfNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const ArraySubscriptNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const BinaryOpNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const UnaryOpNode *node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP>
+  Visit(const TernaryOpNode *node) = 0;
 };
 
 } // namespace lldb_private::dil

--- a/lldb/include/lldb/ValueObject/DILEval.h
+++ b/lldb/include/lldb/ValueObject/DILEval.h
@@ -9,13 +9,32 @@
 #ifndef LLDB_VALUEOBJECT_DILEVAL_H
 #define LLDB_VALUEOBJECT_DILEVAL_H
 
+#include "lldb/ValueObject/DILAST.h"
+#include "lldb/ValueObject/DILParser.h"
 #include <memory>
 #include <vector>
 
-#include "lldb/ValueObject/DILAST.h"
-#include "lldb/ValueObject/DILParser.h"
-
 namespace lldb_private::dil {
+
+/// Given the name of an identifier (variable name, member name, type name,
+/// etc.), find the ValueObject for that name (if it exists) and create and
+/// return an IdentifierInfo object containing all the relevant information
+/// about that object (for DIL parsing and evaluating).
+std::unique_ptr<IdentifierInfo> LookupIdentifier(
+    llvm::StringRef name_ref, std::shared_ptr<StackFrame> stack_frame,
+    lldb::DynamicValueType use_dynamic, CompilerType *scope_ptr = nullptr);
+
+std::unique_ptr<IdentifierInfo> LookupGlobalIdentifier(
+    llvm::StringRef name_ref, std::shared_ptr<StackFrame> stack_frame,
+    lldb::TargetSP target_sp, lldb::DynamicValueType use_dynamic,
+    CompilerType *scope_ptr = nullptr);
+
+/// Get the appropriate ValueObjectSP, consulting the use_dynamic and
+/// use_synthetic options passed.
+lldb::ValueObjectSP GetDynamicOrSyntheticValue(
+    lldb::ValueObjectSP valobj_sp,
+    lldb::DynamicValueType use_dynamic = lldb::eNoDynamicValues,
+    bool use_synthetic = false);
 
 class FlowAnalysis {
  public:
@@ -29,51 +48,51 @@ class FlowAnalysis {
   bool m_address_of_is_pending;
 };
 
-class DILInterpreter : Visitor {
- public:
-  DILInterpreter(lldb::TargetSP target, llvm::StringRef expr);
-  DILInterpreter(lldb::TargetSP target, llvm::StringRef expr,
-                 lldb::ValueObjectSP scope);
-  DILInterpreter(lldb::TargetSP target, llvm::StringRef expr,
-                 lldb::DynamicValueType use_dynamic);
+class Interpreter : Visitor {
+public:
+  Interpreter(lldb::TargetSP target, llvm::StringRef expr,
+              lldb::DynamicValueType use_dynamic,
+              std::shared_ptr<StackFrame> frame_sp);
 
-  lldb::ValueObjectSP DILEval(const DILASTNode* tree, lldb::TargetSP target_sp,
-                              Status& error);
+  llvm::Expected<lldb::ValueObjectSP> DILEval(const ASTNode *tree,
+                                              lldb::TargetSP target_sp);
 
   void SetContextVars(
       std::unordered_map<std::string, lldb::ValueObjectSP> context_vars);
 
  protected:
-  lldb::ValueObjectSP DILEvalNode(const DILASTNode* node,
-                                  FlowAnalysis* flow = nullptr);
+   llvm::Expected<lldb::ValueObjectSP>
+   DILEvalNode(const ASTNode *node, FlowAnalysis *flow = nullptr);
 
-  bool Success() { return m_error.Success(); }
-
-  Status EvalError() { return std::move(m_error); };
-
-  lldb::ValueObjectSP EvaluateMemberOf(lldb::ValueObjectSP value,
-                                      const std::vector<uint32_t>& path,
-                                      bool use_synthetic,
-                                      bool is_dynamic);
+   lldb::ValueObjectSP EvaluateMemberOf(lldb::ValueObjectSP value,
+                                        const std::vector<uint32_t> &path,
+                                        bool use_synthetic, bool is_dynamic);
 
  private:
   void SetError(ErrorCode error_code, std::string error,
                 uint32_t loc);
 
-  void Visit(const ErrorNode* node) override;
-  void Visit(const ScalarLiteralNode* node) override;
-  void Visit(const StringLiteralNode* node) override;
-  void Visit(const IdentifierNode* node) override;
-  void Visit(const SizeOfNode* node) override;
-  void Visit(const BuiltinFunctionCallNode* node) override;
-  void Visit(const CStyleCastNode* node) override;
-  void Visit(const CxxStaticCastNode* node) override;
-  void Visit(const CxxReinterpretCastNode* node) override;
-  void Visit(const MemberOfNode* node) override;
-  void Visit(const ArraySubscriptNode* node) override;
-  void Visit(const BinaryOpNode* node) override;
-  void Visit(const UnaryOpNode* node) override;
-  void Visit(const TernaryOpNode* node) override;
+  llvm::Expected<lldb::ValueObjectSP>
+  Visit(const ScalarLiteralNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP>
+  Visit(const StringLiteralNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP>
+  Visit(const IdentifierNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP> Visit(const SizeOfNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP>
+  Visit(const BuiltinFunctionCallNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP>
+  Visit(const CStyleCastNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP>
+  Visit(const CxxStaticCastNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP>
+  Visit(const CxxReinterpretCastNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP> Visit(const MemberOfNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP>
+  Visit(const ArraySubscriptNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP> Visit(const BinaryOpNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP> Visit(const UnaryOpNode *node) override;
+  llvm::Expected<lldb::ValueObjectSP> Visit(const TernaryOpNode *node) override;
 
   lldb::ValueObjectSP EvaluateComparison(BinaryOpKind kind,
                                          lldb::ValueObjectSP lhs,
@@ -87,43 +106,43 @@ class DILInterpreter : Visitor {
   lldb::ValueObjectSP EvaluateUnaryPrefixIncrement(lldb::ValueObjectSP rhs);
   lldb::ValueObjectSP EvaluateUnaryPrefixDecrement(lldb::ValueObjectSP rhs);
 
-  lldb::ValueObjectSP EvaluateBinaryAddition(lldb::ValueObjectSP lhs,
-                                             lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinarySubtraction(lldb::ValueObjectSP lhs,
-                                                lldb::ValueObjectSP rhs,
-                                                CompilerType result_type);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinaryAddition(lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinarySubtraction(lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs,
+                            CompilerType result_type);
   lldb::ValueObjectSP EvaluateBinaryMultiplication(lldb::ValueObjectSP lhs,
                                                    lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinaryDivision(lldb::ValueObjectSP lhs,
-                                             lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinaryRemainder(lldb::ValueObjectSP lhs,
-                                              lldb::ValueObjectSP rhs);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinaryDivision(lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinaryRemainder(lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs);
   lldb::ValueObjectSP EvaluateBinaryBitwise(BinaryOpKind kind,
                                             lldb::ValueObjectSP lhs,
                                             lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinaryShift(BinaryOpKind kind,
-                                          lldb::ValueObjectSP lhs,
-                                          lldb::ValueObjectSP rhs);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinaryShift(BinaryOpKind kind, lldb::ValueObjectSP lhs,
+                      lldb::ValueObjectSP rhs);
 
   lldb::ValueObjectSP EvaluateAssignment(lldb::ValueObjectSP lhs,
                                          lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinaryAddAssign(lldb::ValueObjectSP lhs,
-                                              lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinarySubAssign(lldb::ValueObjectSP lhs,
-                                              lldb::ValueObjectSP rhs);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinaryAddAssign(lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinarySubAssign(lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs);
   lldb::ValueObjectSP EvaluateBinaryMulAssign(lldb::ValueObjectSP lhs,
                                               lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinaryDivAssign(lldb::ValueObjectSP lhs,
-                                              lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinaryRemAssign(lldb::ValueObjectSP lhs,
-                                              lldb::ValueObjectSP rhs);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinaryDivAssign(lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinaryRemAssign(lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs);
   lldb::ValueObjectSP EvaluateBinaryBitwiseAssign(BinaryOpKind kind,
                                                   lldb::ValueObjectSP lhs,
                                                   lldb::ValueObjectSP rhs);
-  lldb::ValueObjectSP EvaluateBinaryShiftAssign(BinaryOpKind kind,
-                                                lldb::ValueObjectSP lhs,
-                                                lldb::ValueObjectSP rhs,
-                                                CompilerType comp_assign_type);
+  llvm::Expected<lldb::ValueObjectSP>
+  EvaluateBinaryShiftAssign(BinaryOpKind kind, lldb::ValueObjectSP lhs,
+                            lldb::ValueObjectSP rhs,
+                            CompilerType comp_assign_type);
 
   lldb::ValueObjectSP PointerAdd(lldb::ValueObjectSP lhs, int64_t offset);
   lldb::ValueObjectSP ResolveContextVar(const std::string& name) const;
@@ -148,13 +167,11 @@ class DILInterpreter : Visitor {
 
   std::unordered_map<std::string, lldb::ValueObjectSP> m_context_vars;
 
-  lldb::ValueObjectSP m_result;
-
   lldb::ValueObjectSP m_scope;
 
   lldb::DynamicValueType m_default_dynamic;
 
-  Status m_error;
+  std::shared_ptr<StackFrame> m_exe_ctx_scope;
 };
 
 }  // namespace lldb_private::dil

--- a/lldb/include/lldb/ValueObject/DILLexer.h
+++ b/lldb/include/lldb/ValueObject/DILLexer.h
@@ -10,14 +10,14 @@
 #define LLDB_VALUEOBJECT_DILLEXER_H
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/TargetParser/Host.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/TargetParser/Host.h"
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
 
 namespace lldb_private::dil {
 
@@ -92,7 +92,6 @@ class Token {
     kw_signed,
     kw_sizeof,
     kw_static_cast,
-    kw_this,
     kw_true,
     kw_unsigned,
     kw_void,
@@ -132,23 +131,19 @@ class Token {
     wide_string_literal,
   };
 
-  Token (Kind kind, std::string spelling, uint32_t start) :
-      m_kind(kind), m_spelling(std::move(spelling)), m_start_pos(start) {}
+  Token(Kind kind, std::string spelling, uint32_t start)
+      : m_kind(kind), m_spelling(std::move(spelling)), m_start_pos(start) {}
 
   Kind GetKind() const { return m_kind; }
 
   std::string GetSpelling() const { return m_spelling; }
 
-  bool Is (Kind kind) const { return m_kind == kind; }
+  bool Is(Kind kind) const { return m_kind == kind; }
 
   bool IsNot(Kind kind) const { return m_kind != kind; }
 
-  bool IsOneOf(Kind kind1, Kind kind2) const {
-    return Is(kind1) || Is(kind2);
-  }
-
-  template <typename... Ts> bool IsOneOf(Kind kind, Ts... Ks) const {
-    return Is(kind) || IsOneOf(Ks...);
+  bool IsOneOf(llvm::ArrayRef<Kind> kinds) const {
+    return llvm::is_contained(kinds, m_kind);
   }
 
   uint32_t GetLocation() const { return m_start_pos; }
@@ -176,7 +171,7 @@ class DILLexer {
   static llvm::Expected<DILLexer> Create(llvm::StringRef expr);
 
   /// Return the current token to be handled by the DIL parser.
-  const Token& GetCurrentToken() { return m_lexed_tokens[m_tokens_idx]; }
+  const Token &GetCurrentToken() { return m_lexed_tokens[m_tokens_idx]; }
 
   /// Advance the current token position by N.
   void Advance(uint32_t N = 1) {
@@ -249,5 +244,23 @@ class DILLexer {
 
 } // namespace lldb_private::dil
 
+namespace llvm {
+template <> struct format_provider<lldb_private::dil::Token::Kind> {
+  static void format(const lldb_private::dil::Token::Kind &k, raw_ostream &OS,
+                     llvm::StringRef Options) {
+    OS << "'" << lldb_private::dil::Token::GetTokenName(k) << "'";
+  }
+};
+
+template <> struct format_provider<lldb_private::dil::Token> {
+  static void format(const lldb_private::dil::Token &t, raw_ostream &OS,
+                     llvm::StringRef Options) {
+    lldb_private::dil::Token::Kind kind = t.GetKind();
+    OS << "<'" << t.GetSpelling() << "' ("
+       << lldb_private::dil::Token::GetTokenName(kind) << ")>";
+  }
+};
+
+} // namespace llvm
 
 #endif // LLDB_VALUEOBJECT_DILLEXER_H

--- a/lldb/include/lldb/ValueObject/DILParser.h
+++ b/lldb/include/lldb/ValueObject/DILParser.h
@@ -9,19 +9,30 @@
 #ifndef LLDB_VALUEOBJECT_DILPARSER_H
 #define LLDB_VALUEOBJECT_DILPARSER_H
 
+#include "lldb/Target/ExecutionContextScope.h"
+#include "lldb/Utility/Status.h"
+#include "lldb/ValueObject/DILAST.h"
+#include "lldb/ValueObject/DILLexer.h"
+#include "lldb/ValueObject/DILLiteralParsers.h"
 #include <memory>
 #include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
 
-#include "lldb/Target/ExecutionContextScope.h"
-#include "lldb/Utility/Status.h"
-#include "lldb/ValueObject/DILAST.h"
-#include "lldb/ValueObject/DILLexer.h"
-#include "lldb/ValueObject/DILLiteralParsers.h"
 
 namespace lldb_private::dil {
+
+/// Struct to hold information about member fields. Used by the parser for the
+/// Data Inspection Language (DIL).
+struct MemberInfo {
+  std::optional<std::string> name;
+  CompilerType type;
+  std::optional<uint32_t> bitfield_size_in_bits;
+  bool is_synthetic;
+  bool is_dynamic;
+  lldb::ValueObjectSP val_obj_sp;
+};
 
 /// Finds the member field with the given name and type, stores the child index
 /// corresponding to the field in the idx vector and returns a MemberInfo
@@ -45,6 +56,7 @@ enum class ErrorCode : unsigned char {
   kInvalidExpressionSyntax,
   kInvalidNumericLiteral,
   kInvalidOperandType,
+  kLexerError,
   kUndeclaredIdentifier,
   kNotImplemented,
   kUBDivisionByZero,
@@ -58,9 +70,9 @@ enum class ErrorCode : unsigned char {
 };
 
 std::string FormatDiagnostics(llvm::StringRef input_expr,
-                              const std::string& message, uint32_t loc);
+                              const std::string &message, uint32_t loc);
 
-void SetUbStatus(Status& error, ErrorCode code);
+Status SetUbStatus(ErrorCode code);
 
 /// TypeDeclaration builds information about the literal type definition as
 /// type is being parsed. It doesn't perform semantic analysis for non-basic
@@ -138,178 +150,169 @@ class BuiltinFunctionDef {
 /// EBNF grammar for the parser is described in lldb/docs/dil-expr-lang.ebnf
 class DILParser {
  public:
-  explicit DILParser(llvm::StringRef dil_input_expr, DILLexer lexer,
-                     std::shared_ptr<ExecutionContextScope> exe_ctx_scope,
-                     lldb::DynamicValueType use_dynamic,
-                     bool use_synthetic, bool fragile_ivar,
-                     bool check_ptr_vs_member);
+   static llvm::Expected<ASTNodeUP> Parse(llvm::StringRef dil_input_expr,
+                                          DILLexer lexer,
+                                          std::shared_ptr<StackFrame> frame_sp,
+                                          lldb::DynamicValueType use_dynamic,
+                                          bool use_synthetic, bool fragile_ivar,
+                                          bool check_ptr_vs_member);
 
-  DILASTNodeUP Run(Status& error);
+   ~DILParser() = default;
 
-  ~DILParser() { m_ctx_scope.reset(); }
+   bool UseSynthetic() { return m_use_synthetic; }
 
-  bool UseSynthetic() { return m_use_synthetic; }
+   lldb::DynamicValueType UseDynamic() { return m_use_dynamic; }
 
-  lldb::DynamicValueType UseDynamic() { return m_use_dynamic; }
-
-  using PtrOperator = std::tuple<Token::Kind, uint32_t>;
+   using PtrOperator = std::tuple<Token::Kind, uint32_t>;
 
  private:
-  DILASTNodeUP ParseExpression();
-  DILASTNodeUP ParseAssignmentExpression();
-  DILASTNodeUP ParseLogicalOrExpression();
-  DILASTNodeUP ParseLogicalAndExpression();
-  DILASTNodeUP ParseInclusiveOrExpression();
-  DILASTNodeUP ParseExclusiveOrExpression();
-  DILASTNodeUP ParseAndExpression();
-  DILASTNodeUP ParseEqualityExpression();
-  DILASTNodeUP ParseRelationalExpression();
-  DILASTNodeUP ParseShiftExpression();
-  DILASTNodeUP ParseAdditiveExpression();
-  DILASTNodeUP ParseMultiplicativeExpression();
-  DILASTNodeUP ParseCastExpression();
-  DILASTNodeUP ParseUnaryExpression();
-  DILASTNodeUP ParsePostfixExpression();
-  DILASTNodeUP ParsePrimaryExpression();
+   explicit DILParser(llvm::StringRef dil_input_expr, DILLexer lexer,
+                      std::shared_ptr<StackFrame> frame_sp,
+                      lldb::DynamicValueType use_dynamic, bool use_synthetic,
+                      bool fragile_ivar, bool check_ptr_vs_member,
+                      Status &error);
 
-  std::optional<CompilerType> ParseTypeId(bool must_be_type_id = false);
-  void ParseTypeSpecifierSeq(TypeDeclaration* type_decl);
-  bool ParseTypeSpecifier(TypeDeclaration* type_decl);
-  std::string ParseNestedNameSpecifier();
-  std::string ParseTypeName();
+   llvm::Expected<ASTNodeUP> Run();
 
-  std::string ParseTemplateArgumentList();
-  std::string ParseTemplateArgument();
+   ASTNodeUP ParseExpression();
+   ASTNodeUP ParseAssignmentExpression();
+   ASTNodeUP ParseLogicalOrExpression();
+   ASTNodeUP ParseLogicalAndExpression();
+   ASTNodeUP ParseInclusiveOrExpression();
+   ASTNodeUP ParseExclusiveOrExpression();
+   ASTNodeUP ParseAndExpression();
+   ASTNodeUP ParseEqualityExpression();
+   ASTNodeUP ParseRelationalExpression();
+   ASTNodeUP ParseShiftExpression();
+   ASTNodeUP ParseAdditiveExpression();
+   ASTNodeUP ParseMultiplicativeExpression();
+   ASTNodeUP ParseCastExpression();
+   ASTNodeUP ParseUnaryExpression();
+   ASTNodeUP ParsePostfixExpression();
+   ASTNodeUP ParsePrimaryExpression();
 
-  PtrOperator ParsePtrOperator();
-  CompilerType ResolveTypeDeclarators(
-      CompilerType type,
-      const std::vector<PtrOperator>& ptr_operators);
+   std::optional<CompilerType> ParseTypeId(bool must_be_type_id = false);
+   void ParseTypeSpecifierSeq(TypeDeclaration *type_decl);
+   bool ParseTypeSpecifier(TypeDeclaration *type_decl);
+   std::string ParseNestedNameSpecifier();
+   std::string ParseTypeName();
 
-  bool IsSimpleTypeSpecifierKeyword(Token token) const;
-  bool IsCvQualifier(Token token) const;
-  bool IsPtrOperator(Token token) const;
-  bool HandleSimpleTypeSpecifier(TypeDeclaration* type_decl);
+   std::string ParseTemplateArgumentList();
+   std::string ParseTemplateArgument();
 
-  std::string ParseIdExpression();
-  std::string ParseUnqualifiedId();
-  DILASTNodeUP ParseNumericLiteral();
-  DILASTNodeUP ParseBooleanLiteral();
-  DILASTNodeUP ParseCharLiteral();
-  DILASTNodeUP ParseStringLiteral();
-  DILASTNodeUP ParsePointerLiteral();
-  DILASTNodeUP ParseNumericConstant();
-  DILASTNodeUP ParseFloatingLiteral(NumericLiteralParser& literal,
-                                    Token& token);
-  DILASTNodeUP ParseIntegerLiteral(NumericLiteralParser& literal,
-                                   Token& token);
-  DILASTNodeUP ParseBuiltinFunction(uint32_t loc,
+   PtrOperator ParsePtrOperator();
+   CompilerType
+   ResolveTypeDeclarators(CompilerType type,
+                          const std::vector<PtrOperator> &ptr_operators);
+
+   bool IsSimpleTypeSpecifierKeyword(Token token) const;
+   bool IsCvQualifier(Token token) const;
+   bool IsPtrOperator(Token token) const;
+   bool HandleSimpleTypeSpecifier(TypeDeclaration *type_decl);
+
+   std::string ParseIdExpression();
+   std::string ParseUnqualifiedId();
+   ASTNodeUP ParseNumericLiteral();
+   ASTNodeUP ParseBooleanLiteral();
+   ASTNodeUP ParseCharLiteral();
+   ASTNodeUP ParseStringLiteral();
+   ASTNodeUP ParsePointerLiteral();
+   ASTNodeUP ParseNumericConstant();
+   ASTNodeUP ParseFloatingLiteral(NumericLiteralParser &literal, Token &token);
+   ASTNodeUP ParseIntegerLiteral(NumericLiteralParser &literal, Token &token);
+   ASTNodeUP ParseBuiltinFunction(uint32_t loc,
                                   std::unique_ptr<BuiltinFunctionDef> func_def);
 
-  bool ImplicitConversionIsAllowed(CompilerType src, CompilerType dst,
-                                   bool is_src_literal_zero = false);
-  DILASTNodeUP InsertImplicitConversion(DILASTNodeUP expr, CompilerType type);
+   bool ImplicitConversionIsAllowed(CompilerType src, CompilerType dst,
+                                    bool is_src_literal_zero = false);
+   ASTNodeUP InsertImplicitConversion(ASTNodeUP expr, CompilerType type);
 
-  void ConsumeToken();
+   void BailOut(ErrorCode error_code, const std::string &error, uint32_t loc);
 
-  void BailOut(ErrorCode error_code, const std::string& error,
-               uint32_t loc);
+   void BailOut(Status error);
 
-  void BailOut(Status error);
+   void Expect(Token::Kind kind);
 
-  void Expect(Token::Kind kind);
+   void ExpectOneOf(std::vector<Token::Kind> kinds_vec);
 
-  std::string TokenDescription(const Token& token);
-
-  template <typename... Ts>
-  void ExpectOneOf(Token::Kind k, Ts... ks);
-
-  DILASTNodeUP BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
+   ASTNodeUP BuildCStyleCast(CompilerType type, ASTNodeUP rhs,
                              uint32_t location);
-  DILASTNodeUP BuildCxxCast(Token::Kind kind, CompilerType type,
-                            DILASTNodeUP rhs, uint32_t location);
-  DILASTNodeUP BuildCxxDynamicCast(CompilerType type, DILASTNodeUP rhs,
-                                 uint32_t location);
-  DILASTNodeUP BuildCxxStaticCast(CompilerType type, DILASTNodeUP rhs,
-                                uint32_t location);
-  DILASTNodeUP BuildCxxStaticCastToScalar(CompilerType type, DILASTNodeUP rhs,
-                                        uint32_t location);
-  DILASTNodeUP BuildCxxStaticCastToEnum(CompilerType type, DILASTNodeUP rhs,
-                                      uint32_t location);
-  DILASTNodeUP BuildCxxStaticCastToPointer(CompilerType type, DILASTNodeUP rhs,
-                                         uint32_t location);
-  DILASTNodeUP BuildCxxStaticCastToNullPtr(CompilerType type, DILASTNodeUP rhs,
-                                         uint32_t location);
-  DILASTNodeUP BuildCxxStaticCastToReference(CompilerType type, DILASTNodeUP rhs,
-                                           uint32_t location);
-  DILASTNodeUP BuildCxxStaticCastForInheritedTypes(
-      CompilerType type, DILASTNodeUP rhs, uint32_t location);
-  DILASTNodeUP BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP rhs,
-                                     uint32_t location);
-  DILASTNodeUP BuildUnaryOp(UnaryOpKind kind, DILASTNodeUP rhs,
+   ASTNodeUP BuildCxxCast(Token::Kind kind, CompilerType type, ASTNodeUP rhs,
                           uint32_t location);
-  DILASTNodeUP BuildIncrementDecrement(UnaryOpKind kind, DILASTNodeUP rhs,
-                                     uint32_t location);
-  DILASTNodeUP BuildBinaryOp(BinaryOpKind kind, DILASTNodeUP lhs, DILASTNodeUP rhs,
-                           uint32_t location);
-  CompilerType PrepareBinaryAddition(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
-                                     uint32_t location,
-                                     bool is_comp_assign);
-  CompilerType PrepareBinarySubtraction(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
-                                        uint32_t location,
-                                        bool is_comp_assign);
-  CompilerType PrepareBinaryMulDiv(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
-                                   bool is_comp_assign);
-  CompilerType PrepareBinaryRemainder(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
-                                      bool is_comp_assign);
-  CompilerType PrepareBinaryBitwise(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
-                                    bool is_comp_assign);
-  CompilerType PrepareBinaryShift(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
-                                  bool is_comp_assign);
-  CompilerType PrepareBinaryComparison(BinaryOpKind kind, DILASTNodeUP& lhs,
-                                 DILASTNodeUP& rhs,
+   ASTNodeUP BuildCxxDynamicCast(CompilerType type, ASTNodeUP rhs,
                                  uint32_t location);
-  CompilerType PrepareBinaryLogical(const DILASTNodeUP& lhs,
-                                    const DILASTNodeUP& rhs);
-  DILASTNodeUP BuildBinarySubscript(DILASTNodeUP lhs, DILASTNodeUP rhs,
+   ASTNodeUP BuildCxxStaticCast(CompilerType type, ASTNodeUP rhs,
+                                uint32_t location);
+   ASTNodeUP BuildCxxStaticCastToScalar(CompilerType type, ASTNodeUP rhs,
+                                        uint32_t location);
+   ASTNodeUP BuildCxxStaticCastToEnum(CompilerType type, ASTNodeUP rhs,
+                                      uint32_t location);
+   ASTNodeUP BuildCxxStaticCastToPointer(CompilerType type, ASTNodeUP rhs,
+                                         uint32_t location);
+   ASTNodeUP BuildCxxStaticCastToNullPtr(CompilerType type, ASTNodeUP rhs,
+                                         uint32_t location);
+   ASTNodeUP BuildCxxStaticCastToReference(CompilerType type, ASTNodeUP rhs,
+                                           uint32_t location);
+   ASTNodeUP BuildCxxStaticCastForInheritedTypes(CompilerType type,
+                                                 ASTNodeUP rhs,
+                                                 uint32_t location);
+   ASTNodeUP BuildCxxReinterpretCast(CompilerType type, ASTNodeUP rhs,
+                                     uint32_t location);
+   ASTNodeUP BuildUnaryOp(UnaryOpKind kind, ASTNodeUP rhs, uint32_t location);
+   ASTNodeUP BuildIncrementDecrement(UnaryOpKind kind, ASTNodeUP rhs,
+                                     uint32_t location);
+   ASTNodeUP BuildBinaryOp(BinaryOpKind kind, ASTNodeUP lhs, ASTNodeUP rhs,
+                           uint32_t location);
+   CompilerType PrepareBinaryAddition(ASTNodeUP &lhs, ASTNodeUP &rhs,
+                                      uint32_t location, bool is_comp_assign);
+   CompilerType PrepareBinarySubtraction(ASTNodeUP &lhs, ASTNodeUP &rhs,
+                                         uint32_t location,
+                                         bool is_comp_assign);
+   CompilerType PrepareBinaryMulDiv(ASTNodeUP &lhs, ASTNodeUP &rhs,
+                                    bool is_comp_assign);
+   CompilerType PrepareBinaryRemainder(ASTNodeUP &lhs, ASTNodeUP &rhs,
+                                       bool is_comp_assign);
+   CompilerType PrepareBinaryBitwise(ASTNodeUP &lhs, ASTNodeUP &rhs,
+                                     bool is_comp_assign);
+   CompilerType PrepareBinaryShift(ASTNodeUP &lhs, ASTNodeUP &rhs,
+                                   bool is_comp_assign);
+   CompilerType PrepareBinaryComparison(BinaryOpKind kind, ASTNodeUP &lhs,
+                                        ASTNodeUP &rhs, uint32_t location);
+   CompilerType PrepareBinaryLogical(const ASTNodeUP &lhs,
+                                     const ASTNodeUP &rhs);
+   ASTNodeUP BuildBinarySubscript(ASTNodeUP lhs, ASTNodeUP rhs,
                                   uint32_t location);
-  CompilerType PrepareCompositeAssignment(CompilerType comp_assign_type,
-                                          const DILASTNodeUP& lhs,
-                                          uint32_t location);
-  DILASTNodeUP BuildTernaryOp(DILASTNodeUP cond, DILASTNodeUP lhs, DILASTNodeUP rhs,
+   CompilerType PrepareCompositeAssignment(CompilerType comp_assign_type,
+                                           const ASTNodeUP &lhs,
+                                           uint32_t location);
+   ASTNodeUP BuildTernaryOp(ASTNodeUP cond, ASTNodeUP lhs, ASTNodeUP rhs,
                             uint32_t location);
-  DILASTNodeUP BuildMemberOf(DILASTNodeUP lhs, std::string member_id,
-                            bool is_arrow,
-                            uint32_t location);
+   ASTNodeUP BuildMemberOf(ASTNodeUP lhs, std::string member_id, bool is_arrow,
+                           uint32_t location);
 
-  bool AllowSideEffects() const { return m_allow_side_effects; }
+   bool AllowSideEffects() const { return m_allow_side_effects; }
 
-  void SetAllowSideEffects (bool allow_side_effects) {
-    m_allow_side_effects = allow_side_effects;
-  }
-
-  const IdentifierInfo& GetInfo(const IdentifierNode *node) {
-    return node->info();
-  }
+   void SetAllowSideEffects(bool allow_side_effects) {
+     m_allow_side_effects = allow_side_effects;
+   }
 
   void TentativeParsingRollback(uint32_t saved_idx) {
     m_error.Clear();
     m_dil_lexer.ResetTokenIdx(saved_idx);
-    m_dil_token = m_dil_lexer.GetCurrentToken();
   }
+
+  Token CurToken() { return m_dil_lexer.GetCurrentToken(); }
 
   // Parser doesn't own the evaluation context. The produced AST may depend on
   // it (for example, for source locations), so it's expected that expression
   // context will outlive the parser.
-  std::shared_ptr<ExecutionContextScope> m_ctx_scope;
+  std::shared_ptr<StackFrame> m_ctx_scope;
 
   llvm::StringRef m_input_expr;
 
   DILLexer m_dil_lexer;
-  // The token lexer is stopped at (aka "current token").
-  Token m_dil_token;
   // Holds an error if it occures during parsing.
-  Status m_error;
+  Status &m_error;
 
   bool m_allow_side_effects = true;
 
@@ -320,5 +323,76 @@ class DILParser {
 }; // class DILParser
 
 }  // namespace lldb_private::dil
+
+namespace llvm {
+template <>
+struct format_provider<lldb_private::dil::TypeDeclaration::TypeSpecifier> {
+  static void format(const lldb_private::dil::TypeDeclaration::TypeSpecifier &t,
+                     raw_ostream &OS, llvm::StringRef Options) {
+    switch (t) {
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kVoid:
+      OS << "void";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kBool:
+      OS << "bool";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kChar:
+      OS << "char";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kShort:
+      OS << "short";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kInt:
+      OS << "int";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kLong:
+      OS << "long";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kLongLong:
+      OS << "long long";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kFloat:
+      OS << "float";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kDouble:
+      OS << "double";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kLongDouble:
+      OS << "long double";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kWChar:
+      OS << "wchar_t";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kChar16:
+      OS << "char16_t";
+      break;
+    case lldb_private::dil::TypeDeclaration::TypeSpecifier::kChar32:
+      OS << "char32_t";
+      break;
+    default:
+      OS << "invalid type specifier";
+      break;
+    }
+  }
+};
+
+template <>
+struct format_provider<lldb_private::dil::TypeDeclaration::SignSpecifier> {
+  static void format(const lldb_private::dil::TypeDeclaration::SignSpecifier &t,
+                     raw_ostream &OS, llvm::StringRef Options) {
+    switch (t) {
+    case lldb_private::dil::TypeDeclaration::SignSpecifier::kSigned:
+      OS << "signed";
+      break;
+    case lldb_private::dil::TypeDeclaration::SignSpecifier::kUnsigned:
+      OS << "unsigned";
+      break;
+    default:
+      OS << "invalid sign specifier";
+      break;
+    }
+  }
+};
+} // namespace llvm
 
 #endif  // LLDB_VALUEOBJECT_DILPARSER_H

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -521,16 +521,14 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
   if (use_DIL)
     return DILGetValueForVariableExpressionPath(var_expr, use_dynamic, options,
                                                 var_sp, error);
-  else
-    return LegacyGetValueForVariableExpressionPath(var_expr, use_dynamic,
-                                                   options, var_sp, error);
+
+  return LegacyGetValueForVariableExpressionPath(var_expr, use_dynamic, options,
+                                                 var_sp, error);
 }
 
 ValueObjectSP StackFrame::DILGetValueForVariableExpressionPath(
-      llvm::StringRef var_expr, lldb::DynamicValueType use_dynamic,
-      uint32_t options, lldb::VariableSP &var_sp, Status &error)
-{
-  ValueObjectSP ret_val;
+    llvm::StringRef var_expr, lldb::DynamicValueType use_dynamic,
+    uint32_t options, lldb::VariableSP &var_sp, Status &error) {
 
   const bool check_ptr_vs_member =
       (options & eExpressionPathOptionCheckPtrVsMember) != 0;
@@ -539,41 +537,34 @@ ValueObjectSP StackFrame::DILGetValueForVariableExpressionPath(
   const bool no_synth_child =
       (options & eExpressionPathOptionsNoSyntheticChildren) != 0;
 
-  // Lex the expression
+  // Lex the expression.
   auto lex_or_err = dil::DILLexer::Create(var_expr);
   if (!lex_or_err) {
     error = Status::FromError(lex_or_err.takeError());
     return ValueObjectSP();
   }
-  dil::DILLexer lexer = *lex_or_err;
 
   // Parse the expression.
-  Status parse_error, eval_error;
-  dil::DILParser parser(var_expr, lexer, shared_from_this(), use_dynamic,
-                        !no_synth_child, !no_fragile_ivar, check_ptr_vs_member);
-  dil::DILASTNodeUP tree = parser.Run(parse_error);
-  if (parse_error.Fail()) {
-    error = std::move(parse_error);
+  auto tree_or_error = dil::DILParser::Parse(
+      var_expr, std::move(*lex_or_err), shared_from_this(), use_dynamic,
+      !no_synth_child, !no_fragile_ivar, check_ptr_vs_member);
+  if (!tree_or_error) {
+    error = Status::FromError(tree_or_error.takeError());
     return ValueObjectSP();
   }
 
   // Evaluate the parsed expression.
   lldb::TargetSP target = this->CalculateTarget();
-  dil::DILInterpreter interpreter(target, var_expr, use_dynamic);
+  dil::Interpreter interpreter(target, var_expr, use_dynamic,
+                               shared_from_this());
 
-  ret_val = interpreter.DILEval(tree.get(), target, eval_error);
-  if (eval_error.Fail()) {
-    error = std::move(eval_error);
+  auto valobj_or_error = interpreter.DILEval((*tree_or_error).get(), target);
+  if (!valobj_or_error) {
+    error = Status::FromError(valobj_or_error.takeError());
     return ValueObjectSP();
   }
 
-  if (ret_val) {
-    var_sp = ret_val->GetVariable();
-    if (!var_sp && ret_val->GetParent()) {
-      var_sp = ret_val->GetParent()->GetVariable();
-    }
-  }
-  return ret_val;
+  return *valobj_or_error;
 }
 
 ValueObjectSP StackFrame::LegacyGetValueForVariableExpressionPath(

--- a/lldb/source/ValueObject/DILAST.cpp
+++ b/lldb/source/ValueObject/DILAST.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/ValueObject/DILAST.h"
-
 #include "lldb/API/SBType.h"
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Symbol/VariableList.h"
@@ -16,46 +15,9 @@
 #include "lldb/ValueObject/ValueObjectRegister.h"
 #include "lldb/ValueObject/ValueObjectVariable.h"
 #include "llvm/ADT/StringRef.h"
-
 #include <vector>
 
 namespace lldb_private::dil {
-
-lldb::ValueObjectSP
-GetDynamicOrSyntheticValue(lldb::ValueObjectSP in_valobj_sp,
-                           lldb::DynamicValueType use_dynamic,
-                           bool use_synthetic) {
-  Status error;
-  if (!in_valobj_sp) {
-    error = Status("invalid value object");
-    return in_valobj_sp;
-  }
-  lldb::ValueObjectSP value_sp = in_valobj_sp;
-  Target *target = value_sp->GetTargetSP().get();
-  // If this ValueObject holds an error, then it is valuable for that.
-  if (value_sp->GetError().Fail())
-    return value_sp;
-
-  if (!target)
-    return lldb::ValueObjectSP();
-
-  if (use_dynamic != lldb::eNoDynamicValues) {
-    lldb::ValueObjectSP dynamic_sp = value_sp->GetDynamicValue(use_dynamic);
-    if (dynamic_sp)
-      value_sp = dynamic_sp;
-  }
-
-  if (use_synthetic) {
-    lldb::ValueObjectSP synthetic_sp = value_sp->GetSyntheticValue();
-    if (synthetic_sp)
-      value_sp = synthetic_sp;
-  }
-
-  if (!value_sp)
-    error = Status("invalid value object");
-
-  return value_sp;
-}
 
 BinaryOpKind dil_token_kind_to_binary_op_kind(Token::Kind token_kind) {
   switch (token_kind) {
@@ -143,497 +105,71 @@ bool binary_op_kind_is_comp_assign(BinaryOpKind kind) {
   }
 }
 
-CompilerType DILASTNode::GetDereferencedResultType() const {
+CompilerType ASTNode::GetDereferencedResultType() const {
   auto type = result_type();
   return type.IsReferenceType() ? type.GetNonReferenceType() : type;
 }
 
-std::optional<MemberInfo>
-GetFieldWithNameIndexPath(lldb::ValueObjectSP lhs_val_sp,
-                          CompilerType type,
-                          const std::string& name,
-                          std::vector<uint32_t>* idx,
-                          CompilerType empty_type,
-                          bool use_synthetic,
-                          bool is_dynamic,
-                          bool is_arrow) {
-  bool is_synthetic = false;
-  // Go through the fields first.
-  uint32_t num_fields = type.GetNumFields();
-  lldb::ValueObjectSP empty_valobj_sp;
-  for (uint32_t i = 0; i < num_fields; ++i) {
-    uint64_t bit_offset = 0;
-    uint32_t bitfield_bit_size = 0;
-    bool is_bitfield = false;
-    std::string name_sstr;
-    CompilerType field_type (
-        type.GetFieldAtIndex(
-            i, name_sstr, &bit_offset, &bitfield_bit_size, &is_bitfield));
-    auto field_name = name_sstr.length() == 0 ? std::optional<std::string>()
-                                              : name_sstr;
-    if (field_type.IsValid()) {
-      std::optional<uint32_t> size_in_bits;
-      if (is_bitfield)
-        size_in_bits = bitfield_bit_size;
-      struct MemberInfo field = {field_name, field_type, size_in_bits,
-        is_synthetic, is_dynamic, empty_valobj_sp};
-
-      // Name can be null if this is a padding field.
-      if (field.name == name) {
-        if (lhs_val_sp) {
-          lldb::ValueObjectSP child_valobj_sp =
-              lhs_val_sp->GetChildMemberWithName(name);
-          if (child_valobj_sp &&
-              child_valobj_sp->GetName() == ConstString(name))
-            field.val_obj_sp = child_valobj_sp;
-        }
-
-        if (idx) {
-          assert(idx->empty());
-          // Direct base classes are located before fields, so field members
-          // needs to be offset by the number of base classes.
-          idx->push_back(i + type.GetNumberOfNonEmptyBaseClasses());
-        }
-        return field;
-      } else if (field.type.IsAnonymousType()) {
-        // Every member of an anonymous struct is considered to be a member of
-        // the enclosing struct or union. This applies recursively if the
-        // enclosing struct or union is also anonymous.
-
-        assert(!field.name && "Field should be unnamed.");
-
-        std::optional<MemberInfo> field_in_anon_type =
-            GetFieldWithNameIndexPath(lhs_val_sp, field.type, name, idx,
-                                      empty_type, use_synthetic, is_dynamic,
-                                      is_arrow);
-        if (field_in_anon_type) {
-          if (idx) {
-            idx->push_back(i + type.GetNumberOfNonEmptyBaseClasses());
-          }
-          return field_in_anon_type.value();
-        }
-      }
-    }
-  }
-
-  // LLDB can't access inherited fields of anonymous struct members.
-  if (type.IsAnonymousType()) {
-    return {};
-  }
-
-  // Go through the base classes and look for the field there.
-  uint32_t num_non_empty_bases = 0;
-  uint32_t num_direct_bases = type.GetNumDirectBaseClasses();
-  for (uint32_t i = 0; i < num_direct_bases; ++i) {
-    uint32_t bit_offset;
-    auto base = type.GetDirectBaseClassAtIndex(i, &bit_offset);
-    auto field = GetFieldWithNameIndexPath(lhs_val_sp, base, name, idx,
-                                           empty_type, use_synthetic,
-                                           is_dynamic, is_arrow);
-    if (field) {
-      if (idx) {
-        idx->push_back(num_non_empty_bases);
-      }
-      return field.value();
-    }
-    if (base.GetNumFields() > 0) {
-      num_non_empty_bases += 1;
-    }
-  }
-
-  // Check for synthetic member
-  if (lhs_val_sp && use_synthetic) {
-    lldb::ValueObjectSP child_valobj_sp = lhs_val_sp->GetSyntheticValue();
-    if (child_valobj_sp) {
-      is_synthetic = true;
-      uint32_t child_idx = child_valobj_sp->GetIndexOfChildWithName(name);
-      child_valobj_sp = child_valobj_sp->GetChildMemberWithName(name);
-      if (child_valobj_sp) {
-        CompilerType field_type = child_valobj_sp->GetCompilerType();
-        if (field_type.IsValid()) {
-          struct MemberInfo field = {name, field_type, {}, is_synthetic,
-            is_dynamic, child_valobj_sp};
-          if (idx) {
-            assert(idx->empty());
-            idx->push_back(child_idx);
-          }
-          return field;
-        }
-      }
-    }
-  }
-
-  if (lhs_val_sp) {
-    lldb::ValueObjectSP dynamic_val_sp
-        = lhs_val_sp->GetDynamicValue(lldb::eDynamicDontRunTarget);
-    if (dynamic_val_sp) {
-      CompilerType lhs_type = dynamic_val_sp->GetCompilerType();
-      if (lhs_type.IsPointerType())
-        lhs_type = lhs_type.GetPointeeType();
-      is_dynamic = true;
-      return GetFieldWithNameIndexPath(dynamic_val_sp, lhs_type,
-                                       name, idx, empty_type, use_synthetic,
-                                       is_dynamic, is_arrow);
-    }
-  }
-
-  return {};
+llvm::Expected<lldb::ValueObjectSP> ErrorNode::Accept(Visitor *v) const {
+  llvm_unreachable("Attempted to Visit a DIL ErrorNode");
 }
 
-std::tuple<std::optional<MemberInfo>, std::vector<uint32_t>> GetMemberInfo (
-    lldb::ValueObjectSP lhs_val_sp,
-    CompilerType type,
-    const std::string& name,
-    bool use_synthetic,
-    bool is_arrow) {
-  std::vector<uint32_t> idx;
-  CompilerType empty_type;
-  bool is_dynamic = false;
-  std::optional<MemberInfo> member =
-      GetFieldWithNameIndexPath(lhs_val_sp, type, name, &idx, empty_type,
-                                use_synthetic, is_dynamic, is_arrow);
-  std::reverse(idx.begin(), idx.end());
-  return {member, std::move(idx)};
+llvm::Expected<lldb::ValueObjectSP>
+ScalarLiteralNode::Accept(Visitor *v) const {
+  return v->Visit(this);
 }
 
-static lldb::ValueObjectSP
-LookupStaticIdentifier(lldb::TargetSP target_sp,
-                       const llvm::StringRef &name_ref,
-                       ConstString unqualified_name) {
-  // List global variable with the same "basename". There can be many matches
-  // from other scopes (namespaces, classes), so we do additional filtering
-  // later.
-  VariableList variable_list;
-  ConstString name(name_ref);
-  target_sp->GetImages().FindGlobalVariables(name, 1, variable_list);
-  if (!variable_list.Empty()) {
-    ExecutionContextScope *exe_scope = target_sp->GetProcessSP().get();
-    if (exe_scope == nullptr)
-      exe_scope = target_sp.get();
-    for (const lldb::VariableSP &var_sp : variable_list) {
-      lldb::ValueObjectSP valobj_sp(
-          ValueObjectVariable::Create(exe_scope, var_sp));
-      if (valobj_sp && valobj_sp->GetVariable() &&
-          (valobj_sp->GetVariable()->NameMatches(unqualified_name) ||
-           valobj_sp->GetVariable()->NameMatches(ConstString(name_ref))))
-        return valobj_sp;
-    }
-  }
-  return nullptr;
+llvm::Expected<lldb::ValueObjectSP>
+StringLiteralNode::Accept(Visitor *v) const {
+  return v->Visit(this);
 }
 
-struct EnumMember {
-  CompilerType type;
-  ConstString name;
-  llvm::APSInt value;
-};
-
-static std::vector<EnumMember> GetEnumMembers(CompilerType type) {
-  std::vector<EnumMember> enum_member_list;
-  if (type.IsValid()) {
-    type.ForEachEnumerator(
-        [&enum_member_list](const CompilerType &integer_type, ConstString name,
-                            const llvm::APSInt &value) -> bool {
-          EnumMember enum_member = {integer_type, name, value};
-          enum_member_list.push_back(enum_member);
-          return true; // Keep iterating
-        });
-  }
-  return enum_member_list;
+llvm::Expected<lldb::ValueObjectSP> IdentifierNode::Accept(Visitor *v) const {
+  return v->Visit(this);
 }
 
-CompilerType
-ResolveTypeByName(const std::string &name,
-                  std::shared_ptr<ExecutionContextScope> ctx_scope) {
-  // Internally types don't have global scope qualifier in their names and
-  // LLDB doesn't support queries with it too.
-  llvm::StringRef name_ref(name);
-
-  if (name_ref.starts_with("::"))
-    name_ref = name_ref.drop_front(2);
-
-  std::vector<CompilerType> result_type_list;
-  lldb::TargetSP target_sp = ctx_scope->CalculateTarget();
-  const char *type_name = name_ref.data();
-  if (type_name && type_name[0] && target_sp) {
-    ModuleList &images = target_sp->GetImages();
-    ConstString const_type_name(type_name);
-    TypeQuery query(type_name);
-    TypeResults results;
-    images.FindTypes(nullptr, query, results);
-    for (const lldb::TypeSP &type_sp : results.GetTypeMap().Types())
-      if (type_sp)
-        result_type_list.push_back(type_sp->GetFullCompilerType());
-
-    if (auto process_sp = target_sp->GetProcessSP()) {
-      for (auto *runtime : process_sp->GetLanguageRuntimes()) {
-        if (auto *vendor = runtime->GetDeclVendor()) {
-          auto types = vendor->FindTypes(const_type_name, UINT32_MAX);
-          for (auto type : types)
-            result_type_list.push_back(type);
-        }
-      }
-    }
-
-    if (result_type_list.empty()) {
-      for (auto type_system_sp : target_sp->GetScratchTypeSystems())
-        if (auto compiler_type =
-                type_system_sp->GetBuiltinTypeByName(const_type_name))
-          result_type_list.push_back(compiler_type);
-    }
-  }
-
-  // We've found multiple types, try finding the "correct" one.
-  CompilerType full_match;
-  std::vector<CompilerType> partial_matches;
-
-  for (uint32_t i = 0; i < result_type_list.size(); ++i) {
-    CompilerType type = result_type_list[i];
-    llvm::StringRef type_name_ref = type.GetTypeName().GetStringRef();
-    ;
-
-    if (type_name_ref == name_ref)
-      full_match = type;
-    else if (type_name_ref.ends_with(name_ref))
-      partial_matches.push_back(type);
-  }
-
-  // Full match is always correct.
-  if (full_match.IsValid())
-    return full_match;
-
-  // If we have partial matches, pick a "random" one.
-  if (partial_matches.size() > 0)
-    return partial_matches.back();
-
-  return {};
+llvm::Expected<lldb::ValueObjectSP> SizeOfNode::Accept(Visitor *v) const {
+  return v->Visit(this);
 }
 
-static lldb::VariableSP DILFindVariable(ConstString name,
-                                        VariableList *variable_list) {
-  lldb::VariableSP exact_match;
-  std::vector<lldb::VariableSP> possible_matches;
-
-  typedef std::vector<lldb::VariableSP> collection;
-  typedef collection::iterator iterator;
-
-  iterator pos, end = variable_list->end();
-  for (pos = variable_list->begin(); pos != end; ++pos) {
-    llvm::StringRef str_ref_name = pos->get()->GetName().GetStringRef();
-    // Check for global vars, which might start with '::'.
-    str_ref_name.consume_front("::");
-
-    if (str_ref_name == name.GetStringRef())
-      possible_matches.push_back(*pos);
-    else if (pos->get()->NameMatches(name))
-      possible_matches.push_back(*pos);
-  }
-
-  // Look for exact matches (favors local vars over global vars)
-  auto exact_match_it = llvm::find_if(
-      possible_matches,
-      [&](lldb::VariableSP var_sp) { return var_sp->GetName() == name; });
-
-  if (exact_match_it != llvm::adl_end(possible_matches))
-    exact_match = *exact_match_it;
-
-  if (!exact_match)
-    // Look for a global var exact match.
-    for (auto var_sp : possible_matches) {
-      llvm::StringRef str_ref_name = var_sp->GetName().GetStringRef();
-      if (str_ref_name.size() > 2 && str_ref_name[0] == ':' &&
-          str_ref_name[1] == ':')
-        str_ref_name = str_ref_name.drop_front(2);
-      ConstString tmp_name(str_ref_name);
-      if (tmp_name == name) {
-        exact_match = var_sp;
-        break;
-      }
-    }
-
-  // Take any match at this point.
-  if (!exact_match && possible_matches.size() > 0)
-    exact_match = possible_matches[0];
-
-  return exact_match;
+llvm::Expected<lldb::ValueObjectSP>
+BuiltinFunctionCallNode::Accept(Visitor *v) const {
+  return v->Visit(this);
 }
 
-std::unique_ptr<IdentifierInfo>
-LookupIdentifier(const std::string &name,
-                 std::shared_ptr<ExecutionContextScope> ctx_scope,
-                 lldb::DynamicValueType use_dynamic, CompilerType *scope_ptr) {
-  ConstString name_str(name);
-  llvm::StringRef name_ref = name_str.GetStringRef();
-
-  // Support $rax as a special syntax for accessing registers.
-  // Will return an invalid value in case the requested register doesn't exist.
-  if (name_ref.starts_with("$")) {
-    lldb::ValueObjectSP value_sp;
-    const char *reg_name = name_ref.drop_front(1).data();
-    Target *target = ctx_scope->CalculateTarget().get();
-    Process *process = ctx_scope->CalculateProcess().get();
-    if (target && process) {
-      StackFrame *stack_frame = ctx_scope->CalculateStackFrame().get();
-      if (stack_frame) {
-        lldb::RegisterContextSP reg_ctx(stack_frame->GetRegisterContext());
-        if (reg_ctx) {
-          if (const RegisterInfo *reg_info =
-              reg_ctx->GetRegisterInfoByName(reg_name))
-            value_sp =
-                ValueObjectRegister::Create(stack_frame, reg_ctx, reg_info);
-        }
-      }
-    }
-    if (value_sp)
-      return IdentifierInfo::FromValue(*value_sp);
-    else
-      return nullptr;
-  }
-
-  // Internally values don't have global scope qualifier in their names and
-  // LLDB doesn't support queries with it too.
-  bool global_scope = false;
-  if (name_ref.starts_with("::")) {
-    name_ref = name_ref.drop_front(2);
-    global_scope = true;
-  }
-
-  // If the identifier doesn't refer to the global scope and doesn't have any
-  // other scope qualifiers, try looking among the local and instance variables.
-  if (!global_scope && !name_ref.contains("::")) {
-    if (!scope_ptr || !scope_ptr->IsValid()) {
-      // Lookup in the current frame.
-      lldb::StackFrameSP frame = ctx_scope->CalculateStackFrame();
-      // Try looking for a local variable in current scope.
-      lldb::ValueObjectSP value_sp;
-      lldb::VariableListSP var_list_sp(frame->GetInScopeVariableList(true));
-      VariableList *variable_list = var_list_sp.get();
-      if (variable_list) {
-        lldb::VariableSP var_sp =
-            DILFindVariable(ConstString(name_ref), variable_list);
-        if (var_sp)
-          value_sp = frame->GetValueObjectForFrameVariable(var_sp, use_dynamic);
-      }
-      if (!value_sp)
-        value_sp = frame->FindVariable(ConstString(name_ref));
-
-      if (value_sp)
-        // Force static value, otherwise we can end up with the "real" type.
-        return IdentifierInfo::FromValue(*value_sp);
-
-      // Try looking for an instance variable (class member).
-      ConstString this_string("this");
-      value_sp = frame->FindVariable(this_string);
-      if (value_sp)
-        value_sp = value_sp->GetChildMemberWithName(name_ref.data());
-
-      if (value_sp)
-        // Force static value, otherwise we can end up with the "real" type.
-        return IdentifierInfo::FromValue(*(value_sp->GetStaticValue()));
-
-    }
-  }
-
-  // Try looking for a global or static variable.
-
-  lldb::ValueObjectSP value;
-  if (!global_scope) {
-    // Try looking for static member of the current scope value, e.g.
-    // `ScopeType::NAME`. NAME can include nested struct (`Nested::SUBNAME`),
-    // but it cannot be part of the global scope (start with "::").
-    const char *type_name = "";
-    if (scope_ptr)
-      type_name = scope_ptr->GetCanonicalType().GetTypeName().AsCString();
-    std::string name_with_type_prefix =
-        llvm::formatv("{0}::{1}", type_name, name_ref).str();
-    value = LookupStaticIdentifier(ctx_scope->CalculateTarget(),
-                                   name_with_type_prefix, name_str);
-  }
-
-  // Lookup a regular global variable.
-  if (!value)
-    value = LookupStaticIdentifier(ctx_scope->CalculateTarget(), name_ref,
-                                   name_str);
-
-  // Try looking up enum value.
-  if (!value && name_ref.contains("::")) {
-    auto [enum_typename, enumerator_name] = name_ref.rsplit("::");
-
-    auto type = ResolveTypeByName(enum_typename.str(), ctx_scope);
-    std::vector<EnumMember> enum_members = GetEnumMembers(type);
-
-    for (size_t i = 0; i < enum_members.size(); i++) {
-      EnumMember enum_member = enum_members[i];
-      if (enum_member.name == enumerator_name) {
-        uint64_t bytes = enum_member.value.getZExtValue();
-        uint64_t byte_size = 0;
-        if (auto temp = type.GetByteSize(ctx_scope.get()))
-          byte_size = temp.value();
-        lldb::TargetSP target_sp = ctx_scope->CalculateTarget();
-        lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
-            &bytes, byte_size, target_sp->GetArchitecture().GetByteOrder(),
-            static_cast<uint8_t>(
-                target_sp->GetArchitecture().GetAddressByteSize()));
-        ExecutionContext exe_ctx(
-            ExecutionContextRef(ExecutionContext(target_sp.get(), false)));
-        value = ValueObject::CreateValueObjectFromData("result", *data_sp,
-                                                       exe_ctx, type);
-        break;
-      }
-    }
-  }
-
-  // Last resort, lookup as a register (e.g. `rax` or `rip`).
-  if (!value) {
-    Target *target = ctx_scope->CalculateTarget().get();
-    Process *process = ctx_scope->CalculateProcess().get();
-    if (target && process) {
-      StackFrame *stack_frame = ctx_scope->CalculateStackFrame().get();
-      if (stack_frame) {
-        lldb::RegisterContextSP reg_ctx(stack_frame->GetRegisterContext());
-        if (reg_ctx) {
-          if (const RegisterInfo *reg_info =
-              reg_ctx->GetRegisterInfoByName(name_ref.data()))
-            value =
-                ValueObjectRegister::Create(stack_frame, reg_ctx, reg_info);
-        }
-      }
-    }
-  }
-
-  // Force static value, otherwise we can end up with the "real" type.
-  if (value)
-    return IdentifierInfo::FromValue(*value);
-  else
-    return nullptr;
+llvm::Expected<lldb::ValueObjectSP> CStyleCastNode::Accept(Visitor *v) const {
+  return v->Visit(this);
 }
 
-void ErrorNode::Accept(Visitor *v) const { v->Visit(this); }
+llvm::Expected<lldb::ValueObjectSP>
+CxxStaticCastNode::Accept(Visitor *v) const {
+  return v->Visit(this);
+}
 
-void ScalarLiteralNode::Accept(Visitor *v) const { v->Visit(this); }
+llvm::Expected<lldb::ValueObjectSP>
+CxxReinterpretCastNode::Accept(Visitor *v) const {
+  return v->Visit(this);
+}
 
-void StringLiteralNode::Accept(Visitor *v) const { v->Visit(this); }
+llvm::Expected<lldb::ValueObjectSP> MemberOfNode::Accept(Visitor *v) const {
+  return v->Visit(this);
+}
 
-void IdentifierNode::Accept(Visitor *v) const { v->Visit(this); }
+llvm::Expected<lldb::ValueObjectSP>
+ArraySubscriptNode::Accept(Visitor *v) const {
+  return v->Visit(this);
+}
 
-void SizeOfNode::Accept(Visitor *v) const { v->Visit(this); }
+llvm::Expected<lldb::ValueObjectSP> BinaryOpNode::Accept(Visitor *v) const {
+  return v->Visit(this);
+}
 
-void BuiltinFunctionCallNode::Accept(Visitor *v) const { v->Visit(this); }
+llvm::Expected<lldb::ValueObjectSP> UnaryOpNode::Accept(Visitor *v) const {
+  return v->Visit(this);
+}
 
-void CStyleCastNode::Accept(Visitor *v) const { v->Visit(this); }
-
-void CxxStaticCastNode::Accept(Visitor *v) const { return v->Visit(this); }
-
-void CxxReinterpretCastNode::Accept(Visitor *v) const { v->Visit(this); }
-
-void MemberOfNode::Accept(Visitor *v) const { v->Visit(this); }
-
-void ArraySubscriptNode::Accept(Visitor *v) const { v->Visit(this); }
-
-void BinaryOpNode::Accept(Visitor *v) const { v->Visit(this); }
-
-void UnaryOpNode::Accept(Visitor *v) const { v->Visit(this); }
-
-void TernaryOpNode::Accept(Visitor *v) const { v->Visit(this); }
+llvm::Expected<lldb::ValueObjectSP> TernaryOpNode::Accept(Visitor *v) const {
+  return v->Visit(this);
+}
 
 }  // namespace lldb_private::dil

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -1204,6 +1204,12 @@ Interpreter::Visit(const MemberOfNode *node) {
   lldb::ValueObjectSP base = *base_or_err;
 
   if (node->valobj()) {
+    if (node->valobj()->GetCompilerType().IsReferenceType()) {
+      lldb::ValueObjectSP tmp_obj = node->valobj()->Dereference(error);
+      if (error.Fail())
+        return error.ToError();
+      return tmp_obj;
+    }
     return node->valobj()->GetSP();
   }
 

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -7,20 +7,57 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/ValueObject/DILEval.h"
-
-#include <memory>
-
+#include "lldb/Symbol/VariableList.h"
+#include "lldb/Target/RegisterContext.h"
 #include "lldb/ValueObject/DILAST.h"
 #include "lldb/ValueObject/ValueObject.h"
+#include "lldb/ValueObject/ValueObjectRegister.h"
+#include "lldb/ValueObject/ValueObjectVariable.h"
 #include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
+#include <memory>
 
 namespace lldb_private::dil {
 
-template <typename T>
-bool Compare(BinaryOpKind kind, const T& l, const T& r) {
+lldb::ValueObjectSP
+GetDynamicOrSyntheticValue(lldb::ValueObjectSP in_valobj_sp,
+                           lldb::DynamicValueType use_dynamic,
+                           bool use_synthetic) {
+  Status error;
+  if (!in_valobj_sp) {
+    error = Status("invalid value object");
+    return in_valobj_sp;
+  }
+  lldb::ValueObjectSP value_sp = in_valobj_sp;
+  Target *target = value_sp->GetTargetSP().get();
+  // If this ValueObject holds an error, then it is valuable for that.
+  if (value_sp->GetError().Fail())
+    return value_sp;
+
+  if (!target)
+    return lldb::ValueObjectSP();
+
+  if (use_dynamic != lldb::eNoDynamicValues) {
+    lldb::ValueObjectSP dynamic_sp = value_sp->GetDynamicValue(use_dynamic);
+    if (dynamic_sp)
+      value_sp = dynamic_sp;
+  }
+
+  if (use_synthetic) {
+    lldb::ValueObjectSP synthetic_sp = value_sp->GetSyntheticValue();
+    if (synthetic_sp)
+      value_sp = synthetic_sp;
+  }
+
+  if (!value_sp)
+    error = Status("invalid value object");
+
+  return value_sp;
+}
+
+template <typename T> bool Compare(BinaryOpKind kind, const T &l, const T &r) {
   switch (kind) {
     case BinaryOpKind::EQ:
       return l == r;
@@ -193,49 +230,7 @@ static bool IsInvalidDivisionByMinusOne(lldb::ValueObjectSP lhs_sp,
   return lhs_sp->GetValueAsSigned(0) + (1LLU << (bit_size - 1)) == 0;
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateMemberOf(lldb::ValueObjectSP value,
-                                            const std::vector<uint32_t>& path,
-                                            bool use_synthetic,
-                                            bool is_dynamic) {
-  // The given `value` can be a pointer, but GetChildAtIndex works for pointers
-  // too, so we don't need to dereference it explicitely. This also avoid having
-  // an "ephemeral" parent lldb::ValueObjectSP, representing the dereferenced
-  // value.
-  lldb::ValueObjectSP member_val_sp = value;
-  // Objects from the standard library (e.g. containers, smart pointers) have
-  // synthetic children (e.g. stored values for containers, wrapped object for
-  // smart pointers), but the indexes in `member_index()` array refer to the
-  // actual type members.
-  lldb::DynamicValueType use_dynamic = (!is_dynamic)
-                                       ? lldb::eNoDynamicValues
-                                       : lldb::eDynamicDontRunTarget;
-  for (uint32_t idx : path) {
-    // Force static value, otherwise we can end up with the "real" type.
-    member_val_sp = member_val_sp->GetChildAtIndex(idx, /*can_create*/ true);
-  }
-  if (!member_val_sp && is_dynamic) {
-    lldb::ValueObjectSP dyn_val_sp = value->GetDynamicValue(use_dynamic);
-    if (dyn_val_sp) {
-      for (uint32_t idx : path) {
-        dyn_val_sp = dyn_val_sp->GetChildAtIndex(idx, true);
-      }
-      member_val_sp = dyn_val_sp;
-    }
-  }
-  assert(member_val_sp && "invalid ast: invalid member access");
-
-  // If value is a reference, derefernce it to get to the underlying type. All
-  // operations on a reference should be actually operations on the referent.
-  Status error;
-  if (member_val_sp->GetCompilerType().IsReferenceType()) {
-    member_val_sp = member_val_sp->Dereference(error);
-    assert(member_val_sp && error.Success() && "unable to dereference member val");
-  }
-
-  return member_val_sp;
-}
-
-void SetUbStatus(Status& error, ErrorCode code) {
+Status SetUbStatus(ErrorCode code) {
   llvm::StringRef err_str;
   switch ((int) code) {
     case (int) ErrorCode::kUBDivisionByZero:
@@ -264,81 +259,389 @@ void SetUbStatus(Status& error, ErrorCode code) {
       err_str ="Error: Unknown undefined behavior error.";
       break;
   }
-  error = Status(err_str.str());
+  return Status(err_str.str());
 }
 
-DILInterpreter::DILInterpreter(lldb::TargetSP target,
-                               llvm::StringRef expr)
-    : m_target(std::move(target)), m_expr(expr)
-{
-  m_default_dynamic = lldb::eNoDynamicValues;
-}
-
-DILInterpreter::DILInterpreter(lldb::TargetSP target,
-                               llvm::StringRef expr,
-                               lldb::DynamicValueType use_dynamic)
-    : m_target(std::move(target)), m_expr(expr),
-      m_default_dynamic(use_dynamic) {}
-
-DILInterpreter::DILInterpreter(lldb::TargetSP target,
-                               llvm::StringRef expr,
-                               lldb::ValueObjectSP scope)
-    : m_target(std::move(target)), m_expr(expr),
-      m_scope(std::move(scope))
-{
-  m_default_dynamic = lldb::eNoDynamicValues;
-  // If `m_scope` is a reference, dereference it. All operations on a reference
-  // should be operations on the referent.
-  if (m_scope->GetCompilerType().IsValid() &&
-      m_scope->GetCompilerType().IsReferenceType()) {
-    Status error;
-    m_scope = m_scope->Dereference(error);
+static lldb::ValueObjectSP LookupStaticIdentifier(
+    VariableList &variable_list, std::shared_ptr<StackFrame> exe_scope,
+    llvm::StringRef name_ref, llvm::StringRef unqualified_name) {
+  // First look for an exact match (to the possibly qualified name)
+  for (const lldb::VariableSP &var_sp : variable_list) {
+    lldb::ValueObjectSP valobj_sp(
+        ValueObjectVariable::Create(exe_scope.get(), var_sp));
+    if (valobj_sp && valobj_sp->GetVariable() &&
+        (valobj_sp->GetVariable()->NameMatches(ConstString(name_ref))))
+      return valobj_sp;
   }
+
+  // If the qualified name is the same as the unqualified name there's nothing
+  // more to be done.
+  if (name_ref == unqualified_name)
+    return nullptr;
+
+  // We didn't match the qualified name; try to match the unqualified name.
+  for (const lldb::VariableSP &var_sp : variable_list) {
+    lldb::ValueObjectSP valobj_sp(
+        ValueObjectVariable::Create(exe_scope.get(), var_sp));
+    if (valobj_sp && valobj_sp->GetVariable() &&
+        (valobj_sp->GetVariable()->NameMatches(ConstString(unqualified_name))))
+      return valobj_sp;
+  }
+  return nullptr;
 }
 
-void DILInterpreter::SetContextVars(
+struct EnumMember {
+  CompilerType type;
+  ConstString name;
+  llvm::APSInt value;
+};
+
+static std::vector<EnumMember> GetEnumMembers(CompilerType type) {
+  std::vector<EnumMember> enum_member_list;
+  if (type.IsValid()) {
+    type.ForEachEnumerator(
+        [&enum_member_list](const CompilerType &integer_type, ConstString name,
+                            const llvm::APSInt &value) -> bool {
+          EnumMember enum_member = {integer_type, name, value};
+          enum_member_list.push_back(enum_member);
+          return true; // Keep iterating
+        });
+  }
+  return enum_member_list;
+}
+
+CompilerType
+ResolveTypeByName(const std::string &name,
+                  std::shared_ptr<ExecutionContextScope> ctx_scope) {
+  // Internally types don't have global scope qualifier in their names and
+  // LLDB doesn't support queries with it too.
+  llvm::StringRef name_ref(name);
+
+  if (name_ref.starts_with("::"))
+    name_ref = name_ref.drop_front(2);
+
+  std::vector<CompilerType> result_type_list;
+  lldb::TargetSP target_sp = ctx_scope->CalculateTarget();
+  const char *type_name = name_ref.data();
+  if (type_name && type_name[0] && target_sp) {
+    ModuleList &images = target_sp->GetImages();
+    ConstString const_type_name(type_name);
+    TypeQuery query(type_name);
+    TypeResults results;
+    images.FindTypes(nullptr, query, results);
+    for (const lldb::TypeSP &type_sp : results.GetTypeMap().Types())
+      if (type_sp)
+        result_type_list.push_back(type_sp->GetFullCompilerType());
+
+    if (auto process_sp = target_sp->GetProcessSP()) {
+      for (auto *runtime : process_sp->GetLanguageRuntimes()) {
+        if (auto *vendor = runtime->GetDeclVendor()) {
+          auto types = vendor->FindTypes(const_type_name, UINT32_MAX);
+          for (auto type : types)
+            result_type_list.push_back(type);
+        }
+      }
+    }
+
+    if (result_type_list.empty()) {
+      for (auto type_system_sp : target_sp->GetScratchTypeSystems())
+        if (auto compiler_type =
+                type_system_sp->GetBuiltinTypeByName(const_type_name))
+          result_type_list.push_back(compiler_type);
+    }
+  }
+
+  // We've found multiple types, try finding the "correct" one.
+  CompilerType full_match;
+  std::vector<CompilerType> partial_matches;
+
+  for (uint32_t i = 0; i < result_type_list.size(); ++i) {
+    CompilerType type = result_type_list[i];
+    llvm::StringRef type_name_ref = type.GetTypeName().GetStringRef();
+    ;
+
+    if (type_name_ref == name_ref)
+      full_match = type;
+    else if (type_name_ref.ends_with(name_ref))
+      partial_matches.push_back(type);
+  }
+
+  // Full match is always correct.
+  if (full_match.IsValid())
+    return full_match;
+
+  // If we have partial matches, pick a "random" one.
+  if (partial_matches.size() > 0)
+    return partial_matches.back();
+
+  return {};
+}
+
+static lldb::VariableSP DILFindVariable(ConstString name,
+                                        lldb::VariableListSP variable_list) {
+  lldb::VariableSP exact_match;
+  std::vector<lldb::VariableSP> possible_matches;
+
+  for (lldb::VariableSP var_sp : *variable_list) {
+    llvm::StringRef str_ref_name = var_sp->GetName().GetStringRef();
+    // Check for global vars, which might start with '::'.
+    str_ref_name.consume_front("::");
+
+    if (str_ref_name == name.GetStringRef())
+      possible_matches.push_back(var_sp);
+    else if (var_sp->NameMatches(name))
+      possible_matches.push_back(var_sp);
+  }
+
+  // Look for exact matches (favors local vars over global vars)
+  auto exact_match_it =
+      llvm::find_if(possible_matches, [&](lldb::VariableSP var_sp) {
+        return var_sp->GetName() == name;
+      });
+
+  if (exact_match_it != possible_matches.end())
+    return *exact_match_it;
+
+  // Look for a global var exact match.
+  for (auto var_sp : possible_matches) {
+    llvm::StringRef str_ref_name = var_sp->GetName().GetStringRef();
+    str_ref_name.consume_front("::");
+    if (str_ref_name == name.GetStringRef())
+      return var_sp;
+  }
+
+  // If there's a single non-exact match, take it.
+  if (possible_matches.size() == 1)
+    return possible_matches[0];
+
+  return nullptr;
+}
+
+std::unique_ptr<IdentifierInfo> LookupGlobalIdentifier(
+    llvm::StringRef name_ref, std::shared_ptr<StackFrame> stack_frame,
+    lldb::TargetSP target_sp, lldb::DynamicValueType use_dynamic,
+    CompilerType *scope_ptr) {
+  // First look for match in "local" global variables
+  lldb::VariableListSP variable_list(stack_frame->GetInScopeVariableList(true));
+  name_ref.consume_front("::");
+
+  lldb::ValueObjectSP value_sp;
+  if (variable_list) {
+    lldb::VariableSP var_sp =
+        DILFindVariable(ConstString(name_ref), variable_list);
+    if (var_sp)
+      value_sp =
+          stack_frame->GetValueObjectForFrameVariable(var_sp, use_dynamic);
+  }
+  if (value_sp)
+    return IdentifierInfo::FromValue(*value_sp);
+
+  // Also check for static global vars.
+  if (variable_list) {
+    const char *type_name = "";
+    if (scope_ptr)
+      type_name = scope_ptr->GetCanonicalType().GetTypeName().AsCString();
+    std::string name_with_type_prefix =
+        llvm::formatv("{0}::{1}", type_name, name_ref).str();
+    value_sp = LookupStaticIdentifier(*variable_list, stack_frame,
+                                      name_with_type_prefix, name_ref);
+
+    if (!value_sp)
+      value_sp = LookupStaticIdentifier(*variable_list, stack_frame, name_ref,
+                                        name_ref);
+  }
+
+  if (value_sp)
+    return IdentifierInfo::FromValue(*value_sp);
+
+  // Check for match in modules global variables.
+  VariableList modules_var_list;
+  target_sp->GetImages().FindGlobalVariables(
+      ConstString(name_ref), std::numeric_limits<uint32_t>::max(),
+      modules_var_list);
+  if (modules_var_list.Empty())
+    return nullptr;
+
+  for (const lldb::VariableSP &var_sp : modules_var_list) {
+    std::string qualified_name = llvm::formatv("::{0}", name_ref).str();
+    if (var_sp->NameMatches(ConstString(name_ref)) ||
+        var_sp->NameMatches(ConstString(qualified_name))) {
+      value_sp = ValueObjectVariable::Create(stack_frame.get(), var_sp);
+      break;
+    }
+  }
+
+  if (value_sp)
+    return IdentifierInfo::FromValue(*value_sp);
+
+  return nullptr;
+}
+
+std::unique_ptr<IdentifierInfo>
+LookupIdentifier(llvm::StringRef name_ref,
+                 std::shared_ptr<StackFrame> stack_frame,
+                 lldb::DynamicValueType use_dynamic, CompilerType *scope_ptr) {
+  lldb::ValueObjectSP value_sp;
+  // Support $rax as a special syntax for accessing registers.
+  // Will return an invalid value in case the requested register doesn't exist.
+  if (name_ref.consume_front("$")) {
+    lldb::RegisterContextSP reg_ctx(stack_frame->GetRegisterContext());
+    if (!reg_ctx)
+      return nullptr;
+
+    if (const RegisterInfo *reg_info = reg_ctx->GetRegisterInfoByName(name_ref))
+      value_sp =
+          ValueObjectRegister::Create(stack_frame.get(), reg_ctx, reg_info);
+
+    if (value_sp)
+      return IdentifierInfo::FromValue(*value_sp);
+
+    return nullptr;
+  }
+
+  lldb::VariableListSP variable_list(
+      stack_frame->GetInScopeVariableList(false));
+
+  if (!name_ref.contains("::")) {
+    if (!scope_ptr || !scope_ptr->IsValid()) {
+      // Lookup in the current frame.
+      // Try looking for a local variable in current scope.
+      if (variable_list) {
+        lldb::VariableSP var_sp =
+            DILFindVariable(ConstString(name_ref), variable_list);
+        if (var_sp)
+          value_sp =
+              stack_frame->GetValueObjectForFrameVariable(var_sp, use_dynamic);
+      }
+      if (!value_sp)
+        value_sp = stack_frame->FindVariable(ConstString(name_ref));
+
+      if (value_sp)
+        return IdentifierInfo::FromValue(*value_sp);
+
+      // Try looking for an instance variable (class member).
+      SymbolContext sc = stack_frame->GetSymbolContext(
+          lldb::eSymbolContextFunction | lldb::eSymbolContextBlock);
+      llvm::StringRef ivar_name = sc.GetInstanceVariableName();
+      value_sp = stack_frame->FindVariable(ConstString(ivar_name));
+      if (value_sp)
+        value_sp = value_sp->GetChildMemberWithName(name_ref);
+
+      if (value_sp)
+        return IdentifierInfo::FromValue(*value_sp);
+    }
+  }
+
+  // Try looking up enum value.
+  if (!value_sp && name_ref.contains("::")) {
+    auto [enum_typename, enumerator_name] = name_ref.rsplit("::");
+
+    auto type = ResolveTypeByName(enum_typename.str(), stack_frame);
+    std::vector<EnumMember> enum_members = GetEnumMembers(type);
+
+    for (size_t i = 0; i < enum_members.size(); i++) {
+      EnumMember enum_member = enum_members[i];
+      if (enum_member.name == enumerator_name) {
+        uint64_t bytes = enum_member.value.getZExtValue();
+        uint64_t byte_size = 0;
+        if (auto temp = type.GetByteSize(stack_frame.get()))
+          byte_size = temp.value();
+        lldb::TargetSP target_sp = stack_frame->CalculateTarget();
+        lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
+            &bytes, byte_size, target_sp->GetArchitecture().GetByteOrder(),
+            static_cast<uint8_t>(
+                target_sp->GetArchitecture().GetAddressByteSize()));
+        ExecutionContext exe_ctx(
+            ExecutionContextRef(ExecutionContext(target_sp.get(), false)));
+        value_sp = ValueObject::CreateValueObjectFromData("result", *data_sp,
+                                                          exe_ctx, type);
+        break;
+      }
+    }
+  }
+
+  if (value_sp)
+    return IdentifierInfo::FromValue(*value_sp);
+
+  return nullptr;
+}
+
+Interpreter::Interpreter(lldb::TargetSP target, llvm::StringRef expr,
+                         lldb::DynamicValueType use_dynamic,
+                         std::shared_ptr<StackFrame> frame_sp)
+    : m_target(std::move(target)), m_expr(expr), m_default_dynamic(use_dynamic),
+      m_exe_ctx_scope(frame_sp) {}
+
+void Interpreter::SetContextVars(
     std::unordered_map<std::string, lldb::ValueObjectSP> context_vars) {
   m_context_vars = std::move(context_vars);
 }
 
-lldb::ValueObjectSP DILInterpreter::DILEval(const DILASTNode* tree,
-                                            lldb::TargetSP target_sp,
-                                            Status& error)
-{
-  m_error.Clear();
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::DILEval(const ASTNode *tree, lldb::TargetSP target_sp) {
   // Evaluate an AST.
-  DILEvalNode(tree);
-  // Set the error.
-  error = std::move(m_error);
-  // Return the computed result. If there was an error, it will be invalid.
-  return m_result;
+  auto value_or_error = DILEvalNode(tree);
+
+  // Return the computed result-or-error.
+  return value_or_error;
 }
 
-lldb::ValueObjectSP DILInterpreter::DILEvalNode(const DILASTNode* node,
-                                             FlowAnalysis* flow) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::DILEvalNode(const ASTNode *node, FlowAnalysis *flow) {
   // Set up the evaluation context for the current node.
   m_flow_analysis_chain.push_back(flow);
   // Traverse an AST pointed by the `node`.
-  node->Accept(this);
+  auto value_or_error = node->Accept(this);
   // Cleanup the context.
   m_flow_analysis_chain.pop_back();
-  // Return the computed value for convenience. The caller is responsible for
+  // Return the computed value-or-error. The caller is responsible for
   // checking if an error occured during the evaluation.
-  return m_result;
+  return value_or_error;
 }
 
-void DILInterpreter::SetError(ErrorCode code, std::string error,
-                              uint32_t loc) {
-  assert(m_error.Success() && "interpreter can error only once");
-  m_error = Status(FormatDiagnostics(m_expr, error, loc));
+lldb::ValueObjectSP
+Interpreter::EvaluateMemberOf(lldb::ValueObjectSP value,
+                              const std::vector<uint32_t> &path,
+                              bool use_synthetic, bool is_dynamic) {
+  // The given `value` can be a pointer, but GetChildAtIndex works for pointers
+  // too, so we don't need to dereference it explicitely. This also avoid having
+  // an "ephemeral" parent lldb::ValueObjectSP, representing the dereferenced
+  // value.
+  lldb::ValueObjectSP member_val_sp = value;
+  // Objects from the standard library (e.g. containers, smart pointers) have
+  // synthetic children (e.g. stored values for containers, wrapped object for
+  // smart pointers), but the indexes in `member_index()` array refer to the
+  // actual type members.
+  lldb::DynamicValueType use_dynamic =
+      (!is_dynamic) ? lldb::eNoDynamicValues : lldb::eDynamicDontRunTarget;
+  for (uint32_t idx : path) {
+    member_val_sp = member_val_sp->GetChildAtIndex(idx, /*can_create*/ true);
+  }
+  if (!member_val_sp && is_dynamic) {
+    lldb::ValueObjectSP dyn_val_sp = value->GetDynamicValue(use_dynamic);
+    if (dyn_val_sp) {
+      for (uint32_t idx : path) {
+        dyn_val_sp = dyn_val_sp->GetChildAtIndex(idx, true);
+      }
+      member_val_sp = dyn_val_sp;
+    }
+  }
+  assert(member_val_sp && "invalid ast: invalid member access");
+
+  // If value is a reference, derefernce it to get to the underlying type. All
+  // operations on a reference should be actually operations on the referent.
+  Status error;
+  if (member_val_sp->GetCompilerType().IsReferenceType()) {
+    member_val_sp = member_val_sp->Dereference(error);
+    assert(member_val_sp && error.Success() &&
+           "unable to dereference member val");
+  }
+
+  return member_val_sp;
 }
 
-void DILInterpreter::Visit(const ErrorNode* node) {
-  // The AST is not valid.
-  m_result = lldb::ValueObjectSP();
-}
-
-void DILInterpreter::Visit(const ScalarLiteralNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const ScalarLiteralNode *node) {
   CompilerType result_type = node->result_type();
   Scalar value = node->GetValue();
   if (result_type.IsBoolean()) {
@@ -346,26 +649,27 @@ void DILInterpreter::Visit(const ScalarLiteralNode* node) {
     bool b_val = false;
     if (int_val == 1)
       b_val = true;
-    m_result = ValueObject::CreateValueObjectFromBool(m_target, b_val,
-                                                      "result");
-  } else if (result_type.IsFloat()) {
-    llvm::APFloat val = value.GetAPFloat();
-    m_result = ValueObject::CreateValueObjectFromAPFloat(m_target, val,
-                                                     result_type,
-                                                     "result");
-  } else if (result_type.IsInteger() ||
-             result_type.IsNullPtrType() ||
-             result_type.IsPointerType()) {
-    llvm::APInt val = value.GetAPSInt();
-    m_result = ValueObject::CreateValueObjectFromAPInt(m_target, val,
-                                                       result_type,
-                                                       "result");
-  } else {
-    m_result =  lldb::ValueObjectSP();
+    return ValueObject::CreateValueObjectFromBool(m_target, b_val, "result");
   }
+
+  if (result_type.IsFloat()) {
+    llvm::APFloat val = value.GetAPFloat();
+    return ValueObject::CreateValueObjectFromAPFloat(m_target, val, result_type,
+                                                     "result");
+  }
+
+  if (result_type.IsInteger() || result_type.IsNullPtrType() ||
+      result_type.IsPointerType()) {
+    llvm::APInt val = value.GetAPSInt();
+    return ValueObject::CreateValueObjectFromAPInt(m_target, val, result_type,
+                                                   "result");
+  }
+
+  return lldb::ValueObjectSP();
 }
 
-void DILInterpreter::Visit(const StringLiteralNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const StringLiteralNode *node) {
   CompilerType result_type = node->result_type();
   std::string val = node->GetValue();
   ExecutionContext exe_ctx(m_target.get(), false);
@@ -375,83 +679,87 @@ void DILInterpreter::Visit(const StringLiteralNode* node) {
   lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
       reinterpret_cast<const void*>(val.data()), byte_size,
       exe_ctx.GetByteOrder(), exe_ctx.GetAddressByteSize());
-  m_result = ValueObject::CreateValueObjectFromData("result", *data_sp,
-                                                    exe_ctx,
-                                                    result_type);
+  return ValueObject::CreateValueObjectFromData("result", *data_sp, exe_ctx,
+                                                result_type);
 }
 
-void DILInterpreter::Visit(const IdentifierNode* node) {
-  auto identifier = static_cast<const IdentifierInfo&>(node->info());
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const IdentifierNode *node) {
+  lldb::DynamicValueType use_dynamic = node->GetUseDynamic();
+
+  std::unique_ptr<IdentifierInfo> identifier =
+      LookupIdentifier(node->GetName(), m_exe_ctx_scope, use_dynamic);
+
+  if (!identifier)
+    identifier = LookupGlobalIdentifier(node->GetName(), m_exe_ctx_scope,
+                                        m_target, use_dynamic);
+
+  if (!identifier) {
+    std::string errMsg =
+        llvm::formatv("use of undeclared identifier '{0}'", node->GetName());
+    Status error = Status(
+        (uint32_t)ErrorCode::kUndeclaredIdentifier, lldb::eErrorTypeGeneric,
+        FormatDiagnostics(m_expr, errMsg, node->GetLocation()));
+    return error.ToError();
+  }
 
   lldb::ValueObjectSP val;
   lldb::TargetSP target_sp;
-  Status error;
-  switch (identifier.GetKind()) {
+  switch (identifier->GetKind()) {
     using Kind = IdentifierInfo::Kind;
     case Kind::eValue:
-      val = identifier.GetValue();
-      target_sp = val->GetTargetSP();
-      assert(target_sp && target_sp->IsValid()
-             && "invalid ast: invalid identifier value");
+      val = identifier->GetValue();
       break;
 
     case Kind::eContextArg:
       assert(node->is_context_var() && "invalid ast: context var expected");
-      val = ResolveContextVar(node->name());
-      target_sp = val->GetTargetSP();
-      if (!target_sp || !target_sp->IsValid()) {
-        SetError(
-            ErrorCode::kUndeclaredIdentifier,
-            llvm::formatv("use of undeclared identifier '{0}'", node->name()),
-            node->GetLocation());
-        m_result = lldb::ValueObjectSP();
-        return;
+      val = ResolveContextVar(node->GetName());
+      if (!val) {
+        Status error = Status(
+            (uint32_t)ErrorCode::kUndeclaredIdentifier, lldb::eErrorTypeGeneric,
+            FormatDiagnostics(
+                m_expr,
+                llvm::formatv("use of undeclared identifier '{0}'",
+                              node->GetName()),
+                node->GetLocation()));
+        return error.ToError();
       }
-      if (!node->GetDereferencedResultType().CompareTypes(val->GetCompilerType())) {
-        SetError(ErrorCode::kInvalidOperandType,
-                 llvm::formatv("unexpected type of context variable '{0}' "
-                               "(expected {1}, got {2})",
-                               node->name(),
-                               node->GetDereferencedResultType().TypeDescription(),
-                               val->GetCompilerType().TypeDescription()),
-                 node->GetLocation());
-        m_result = lldb::ValueObjectSP();
-        return;
+      if (!node->GetDereferencedResultType().CompareTypes(
+              val->GetCompilerType())) {
+        Status error = Status(
+            (uint32_t)ErrorCode::kInvalidOperandType, lldb::eErrorTypeGeneric,
+            FormatDiagnostics(
+                m_expr,
+                llvm::formatv(
+                    "unexpected type of context variable"
+                    " '{0}' (expected {1}, got {2})",
+                    node->GetName(),
+                    node->GetDereferencedResultType().TypeDescription(),
+                    val->GetCompilerType().TypeDescription()),
+                node->GetLocation()));
+        return error.ToError();
       }
       break;
 
     case Kind::eMemberPath:
-      target_sp = m_scope->GetTargetSP();
-      if (!target_sp || !target_sp->IsValid()) {
-        SetError(
-            ErrorCode::kUnknown,
-            llvm::formatv(
-                "unable to resolve '{0}', evaluation requires a value context",
-                node->name()),
-            node->GetLocation());
-        m_result = lldb::ValueObjectSP();
-        return;
-      }
-      val = EvaluateMemberOf(m_scope, identifier.GetPath(), false, false);
+      val = EvaluateMemberOf(m_scope, identifier->GetPath(), false, false);
       break;
 
     default:
       assert(false && "invalid ast: invalid identifier kind");
-  }
+    }
 
   if (val->GetCompilerType().IsReferenceType()) {
     Status error;
     val = val->Dereference(error);
+    if (error.Fail())
+      return error.ToError();
   }
 
-  target_sp = val->GetTargetSP();
-  assert(target_sp && target_sp->IsValid() &&
-         "identifier doesn't resolve to a valid value");
-
-  m_result = val;
+  return val;
 }
 
-void DILInterpreter::Visit(const SizeOfNode* node) {
+llvm::Expected<lldb::ValueObjectSP> Interpreter::Visit(const SizeOfNode *node) {
   auto operand = node->operand();
 
   uint64_t deref_byte_size = 0;
@@ -472,20 +780,22 @@ void DILInterpreter::Visit(const SizeOfNode* node) {
   lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
       reinterpret_cast<const void*>(&size), byte_size,
       exe_ctx.GetByteOrder(), exe_ctx.GetAddressByteSize());
-  m_result = ValueObject::CreateValueObjectFromData("result", *data_sp, exe_ctx,
-                                                    type);
+  return ValueObject::CreateValueObjectFromData("result", *data_sp, exe_ctx,
+                                                type);
 }
 
-void DILInterpreter::Visit(const BuiltinFunctionCallNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const BuiltinFunctionCallNode *node) {
   if (node->name() == "__log2") {
     assert(node->arguments().size() == 1 &&
            "invalid ast: expected exactly one argument to `__log2`");
     // Get the first (and the only) argument and evaluate it.
-    auto& arg = node->arguments()[0];
-    lldb::ValueObjectSP val = DILEvalNode(arg.get());
-    if (!val) {
-      return;
+    auto &arg = node->arguments()[0];
+    auto val_or_err = DILEvalNode(arg.get());
+    if (!val_or_err) {
+      return val_or_err;
     }
+    lldb::ValueObjectSP val = *val_or_err;
     assert(val->GetCompilerType().IsInteger() &&
            "invalid ast: argument to __log2 must be an interger");
 
@@ -507,21 +817,20 @@ void DILInterpreter::Visit(const BuiltinFunctionCallNode* node) {
     lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
         reinterpret_cast<const void*>(&ret), byte_size,
         exe_ctx.GetByteOrder(), exe_ctx.GetAddressByteSize());
-    m_result =
-        ValueObject::CreateValueObjectFromData("result", *data_sp,
-                                               exe_ctx, target_type);
-    return;
+    return ValueObject::CreateValueObjectFromData("result", *data_sp, exe_ctx,
+                                                  target_type);
   }
 
   if (node->name() == "__findnonnull") {
     assert(node->arguments().size() == 2 &&
            "invalid ast: expected exactly two arguments to `__findnonnull`");
 
-    auto& arg1 = node->arguments()[0];
-    lldb::ValueObjectSP val1_sp = DILEvalNode(arg1.get());
-    if (!val1_sp) {
-      return;
+    auto &arg1 = node->arguments()[0];
+    auto val_or_err = DILEvalNode(arg1.get());
+    if (!val_or_err) {
+      return val_or_err;
     }
+    lldb::ValueObjectSP val1_sp = *val_or_err;
 
     // Resolve data address for the first argument.
     uint64_t addr;
@@ -531,29 +840,36 @@ void DILInterpreter::Visit(const BuiltinFunctionCallNode* node) {
     } else if (val1_sp->GetCompilerType().IsArrayType()) {
       addr = val1_sp->GetLoadAddress();
     } else {
-      SetError(ErrorCode::kInvalidOperandType,
-               llvm::formatv("no known conversion from '{0}' to 'T*' for 1st "
-                             "argument of __findnonnull()",
-                             val1_sp->GetCompilerType().GetTypeName()),
-               arg1->GetLocation());
-      return;
+      Status error = Status(
+          (uint32_t)ErrorCode::kInvalidOperandType, lldb::eErrorTypeGeneric,
+          FormatDiagnostics(
+              m_expr,
+              llvm::formatv("no known conversion from '{0}' to 'T*' for 1st "
+                            "argument of __findnonnull()",
+                            val1_sp->GetCompilerType().GetTypeName()),
+              arg1->GetLocation()));
+      return error.ToError();
     }
 
-    auto& arg2 = node->arguments()[1];
-    lldb::ValueObjectSP val2_sp = DILEvalNode(arg2.get());
-    if (!val2_sp) {
-      return;
+    auto &arg2 = node->arguments()[1];
+    auto val2_or_err = DILEvalNode(arg2.get());
+    if (!val2_or_err) {
+      return val2_or_err;
     }
+    lldb::ValueObjectSP val2_sp = *val2_or_err;
     int64_t size = val2_sp->GetValueAsSigned(0);
 
     if (size < 0 || size > 100000000) {
-      SetError(ErrorCode::kInvalidOperandType,
-               llvm::formatv(
-                   "passing in a buffer size ('{0}') that is negative or in "
-                   "excess of 100 million to __findnonnull() is not allowed.",
-                   size),
-               arg2->GetLocation());
-      return;
+      Status error = Status(
+          (uint32_t)ErrorCode::kInvalidOperandType, lldb::eErrorTypeGeneric,
+          FormatDiagnostics(
+              m_expr,
+              llvm::formatv(
+                  "passing in a buffer size ('{0}') that is negative or in "
+                  "excess of 100 million to __findnonnull() is not allowed.",
+                  size),
+              arg2->GetLocation()));
+      return error.ToError();
     }
 
     lldb::ProcessSP process = m_target->GetProcessSP();
@@ -579,22 +895,23 @@ void DILInterpreter::Visit(const BuiltinFunctionCallNode* node) {
           process->ReadMemory(addr + i * ptr_size, &memory, ptr_size, error);
 
       if (error.Fail() || read != ptr_size) {
-        SetError(ErrorCode::kUnknown,
-                 llvm::formatv("error calling __findnonnull(): {0}",
-                               error.AsCString() ? error.AsCString()
-                                                 : "cannot read memory"),
-                 node->GetLocation());
-        return;
+        Status error =
+            Status((uint32_t)ErrorCode::kUnknown, lldb::eErrorTypeGeneric,
+                   FormatDiagnostics(
+                       m_expr,
+                       llvm::formatv("error calling __findnonnull(): {0}",
+                                     error.AsCString() ? error.AsCString()
+                                                       : "cannot read memory"),
+                       node->GetLocation()));
+        return error.ToError();
       }
 
       if (memory != 0) {
         lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
             reinterpret_cast<const void*>(&i), byte_size,
             exe_ctx.GetByteOrder(), exe_ctx.GetAddressByteSize());
-        m_result = ValueObject::CreateValueObjectFromData("result", *data_sp,
-                                                          exe_ctx,
-                                                          target_type);
-        return;
+        return ValueObject::CreateValueObjectFromData("result", *data_sp,
+                                                      exe_ctx, target_type);
       }
     }
 
@@ -603,58 +920,57 @@ void DILInterpreter::Visit(const BuiltinFunctionCallNode* node) {
     lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
         reinterpret_cast<const void*>(&ret), byte_size,
         exe_ctx.GetByteOrder(), exe_ctx.GetAddressByteSize());
-    m_result = ValueObject::CreateValueObjectFromData("result", *data_sp,
-                                                      exe_ctx,
-                                                      target_type);
-    return;
+    return ValueObject::CreateValueObjectFromData("result", *data_sp, exe_ctx,
+                                                  target_type);
   }
 
-  assert(false && "invalid ast: unknown builtin function");
-  m_result = lldb::ValueObjectSP();
+  Status error("invalid ast: unknown builtin function");
+  return error.ToError();
 }
 
-void DILInterpreter::Visit(const CStyleCastNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const CStyleCastNode *node) {
   // Get the type and the value we need to cast.
   auto type = node->type();
-  auto rhs = DILEvalNode(node->operand());
-  if (!rhs) {
-    return;
+  auto rhs_or_err = DILEvalNode(node->operand());
+  if (!rhs_or_err) {
+    return rhs_or_err;
   }
+  lldb::ValueObjectSP rhs = *rhs_or_err;
 
   if (rhs->GetCompilerType().IsReferenceType()) {
     Status error;
     rhs = rhs->Dereference(error);
+    if (error.Fail())
+      return error.ToError();
   }
 
   switch (node->cast_kind()) {
     case CStyleCastKind::eEnumeration: {
       assert(type.IsEnumerationType() &&
              "invalid ast: target type should be an enumeration.");
+      if (rhs->GetCompilerType().IsFloat())
+        return rhs->CastToEnumType(type);
 
-      if (rhs->GetCompilerType().IsFloat()) {
-        m_result = rhs->CastToEnumType(type);
-      } else if (rhs->GetCompilerType().IsInteger() ||
-                 rhs->GetCompilerType().IsEnumerationType()) {
-        m_result = rhs->CastToEnumType(type);
-      } else {
-        assert(false &&
-               "invalid ast: operand is not convertible to enumeration type");
-      }
-      return;
+      if (rhs->GetCompilerType().IsInteger() ||
+          rhs->GetCompilerType().IsEnumerationType())
+        return rhs->CastToEnumType(type);
+
+      Status error(
+          "invalid ast: operand is not convertible to enumeration type");
+      return error.ToError();
     }
     case CStyleCastKind::eNullptr: {
       assert(
           (type.GetCanonicalType().GetBasicTypeEnumeration() ==
            lldb::eBasicTypeNullPtr)
           && "invalid ast: target type should be a nullptr_t.");
-      m_result = ValueObject::CreateValueObjectFromNullptr(m_target, type, "result");
-      return;
+      return ValueObject::CreateValueObjectFromNullptr(m_target, type,
+                                                       "result");
     }
     case CStyleCastKind::eReference: {
       lldb::ValueObjectSP rhs_sp(GetDynamicOrSyntheticValue(rhs));
-      m_result =
-          lldb::ValueObjectSP(rhs_sp->Cast(type.GetNonReferenceType()));
-      return;
+      return lldb::ValueObjectSP(rhs_sp->Cast(type.GetNonReferenceType()));
     }
     case CStyleCastKind::eNone: {
 
@@ -667,17 +983,17 @@ void DILInterpreter::Visit(const CStyleCastNode* node) {
           // Pick an appropriate cast.
           if (rhs->GetCompilerType().IsPointerType()
               || rhs->GetCompilerType().IsNullPtrType()) {
-            m_result = rhs->CastToBasicType(type);
-          } else if (rhs->GetCompilerType().IsScalarType()) {
-            m_result = rhs->CastToBasicType(type);
-            //m_result = rhs->CastScalarToBasicType(type, m_error);
-          } else if (rhs->GetCompilerType().IsEnumerationType()) {
-            m_result = rhs->CastToBasicType(type);
-          } else {
-            assert(false &&
-                   "invalid ast: operand is not convertible to arithmetic type");
+            return rhs->CastToBasicType(type);
           }
-          return;
+          if (rhs->GetCompilerType().IsScalarType()) {
+            return rhs->CastToBasicType(type);
+          }
+          if (rhs->GetCompilerType().IsEnumerationType()) {
+            return rhs->CastToBasicType(type);
+          }
+          Status error(
+              "invalid ast: operand is not convertible to arithmetic type");
+          return error.ToError();
         }
         case TypePromotionCastKind::ePointer: {
           assert(type.IsPointerType() &&
@@ -687,33 +1003,35 @@ void DILInterpreter::Visit(const CStyleCastNode* node) {
                           : GetUInt64(rhs);
           llvm::StringRef name = "result";
           ExecutionContext exe_ctx(m_target.get(), false);
-          m_result =
-              ValueObject::CreateValueObjectFromAddress(name, addr, exe_ctx,
-                                                        type,
-                                                        /* do_deref */ false);
-          return;
+          return ValueObject::CreateValueObjectFromAddress(
+              name, addr, exe_ctx, type,
+              /* do_deref */ false);
         }
         case TypePromotionCastKind::eNone:
-          return;
+          return lldb::ValueObjectSP();
       }
     }
   }
 
-  assert(false && "invalid ast: unexpected c-style cast kind");
-  m_result = lldb::ValueObjectSP();
+  Status error("invalid ast: unexpected c-style cast kind");
+  return error.ToError();
 }
 
-void DILInterpreter::Visit(const CxxStaticCastNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const CxxStaticCastNode *node) {
   // Get the type and the value we need to cast.
   auto type = node->type();
-  auto rhs = DILEvalNode(node->operand());
-  if (!rhs) {
-    return;
+  auto rhs_or_err = DILEvalNode(node->operand());
+  if (!rhs_or_err) {
+    return rhs_or_err;
   }
+  lldb::ValueObjectSP rhs = *rhs_or_err;
 
   if (rhs->GetCompilerType().IsReferenceType()) {
     Status error;
     rhs = rhs->Dereference(error);
+    if (error.Fail())
+      return error.ToError();
   }
 
   switch (node->cast_kind()) {
@@ -721,42 +1039,39 @@ void DILInterpreter::Visit(const CxxStaticCastNode* node) {
       assert(type.CompareTypes(rhs->GetCompilerType()) &&
              "invalid ast: types should be the same");
       lldb::ValueObjectSP rhs_sp(GetDynamicOrSyntheticValue(rhs));
-      m_result = lldb::ValueObjectSP(rhs_sp->Cast(type));
-      return;
+      return lldb::ValueObjectSP(rhs_sp->Cast(type));
     }
 
     case CxxStaticCastKind::eEnumeration: {
-      if (rhs->GetCompilerType().IsFloat()) {
-        m_result = rhs->CastToEnumType(type);
-      } else if (rhs->GetCompilerType().IsInteger() ||
-                 rhs->GetCompilerType().IsEnumerationType()) {
-        m_result = rhs->CastToEnumType(type);
-      } else {
-        assert(false &&
-               "invalid ast: operand is not convertible to enumeration type");
-      }
-      return;
+      if (rhs->GetCompilerType().IsFloat())
+        return rhs->CastToEnumType(type);
+      if (rhs->GetCompilerType().IsInteger() ||
+          rhs->GetCompilerType().IsEnumerationType())
+        return rhs->CastToEnumType(type);
+      Status error(
+          "invalid ast: operand is not convertible to enumeration type");
+      return error.ToError();
     }
 
     case CxxStaticCastKind::eNullptr: {
-      m_result = ValueObject::CreateValueObjectFromNullptr(m_target, type, "result");
-      return;
+      return ValueObject::CreateValueObjectFromNullptr(m_target, type,
+                                                       "result");
     }
 
     case CxxStaticCastKind::eDerivedToBase: {
       llvm::Expected<lldb::ValueObjectSP> result =
           rhs->CastDerivedToBaseType(type, node->idx());
       if (result)
-        m_result = *result;
-      return;
+        return *result;
+      return result;
     }
 
     case CxxStaticCastKind::eBaseToDerived: {
       llvm::Expected<lldb::ValueObjectSP> result =
           rhs->CastBaseToDerivedType(type, node->offset());
       if (result)
-        m_result = *result;
-      return;
+        return *result;
+      return result;
     }
     case CxxStaticCastKind::eNone: {
 
@@ -767,17 +1082,16 @@ void DILInterpreter::Visit(const CxxStaticCastNode* node) {
           if (rhs->GetCompilerType().IsPointerType()
               || rhs->GetCompilerType().IsNullPtrType()) {
             assert(type.IsBoolean() && "invalid ast: target type should be bool");
-            m_result = rhs->CastToBasicType(type);
-          } else if (rhs->GetCompilerType().IsScalarType()) {
-            //m_result = rhs->CastScalarToBasicType(type, m_error);
-            m_result = rhs->CastToBasicType(type);
-          } else if (rhs->GetCompilerType().IsEnumerationType()) {
-            m_result = rhs->CastToBasicType(type);
-          } else {
-            assert(false &&
-                   "invalid ast: operand is not convertible to arithmetic type");
+            return rhs->CastToBasicType(type);
           }
-          return;
+          if (rhs->GetCompilerType().IsScalarType())
+            return rhs->CastToBasicType(type);
+          if (rhs->GetCompilerType().IsEnumerationType())
+            return rhs->CastToBasicType(type);
+
+          Status error(
+              "invalid ast: operand is not convertible to arithmetic type");
+          return error.ToError();
         }
 
         case TypePromotionCastKind::ePointer: {
@@ -789,49 +1103,40 @@ void DILInterpreter::Visit(const CxxStaticCastNode* node) {
                           : rhs->GetValueAsUnsigned(0);
           llvm::StringRef name = "result";
           ExecutionContext exe_ctx(m_target.get(), false);
-          m_result =
-              ValueObject::CreateValueObjectFromAddress(name, addr, exe_ctx,
-                                                        type,
-                                                        /* do_deref */ false);
-          return;
+          return ValueObject::CreateValueObjectFromAddress(
+              name, addr, exe_ctx, type,
+              /* do_deref */ false);
         }
         case TypePromotionCastKind::eNone:
-          return;
+          return lldb::ValueObjectSP();
       }
     }
   }
+  return lldb::ValueObjectSP();
 }
 
-void DILInterpreter::Visit(const CxxReinterpretCastNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const CxxReinterpretCastNode *node) {
   // Get the type and the value we need to cast.
   auto type = node->type();
-  auto rhs = DILEvalNode(node->operand());
-  if (!rhs) {
-    return;
+  auto rhs_or_err = DILEvalNode(node->operand());
+  if (!rhs_or_err) {
+    return rhs_or_err;
   }
+  lldb::ValueObjectSP rhs = *rhs_or_err;
 
   if (rhs->GetCompilerType().IsReferenceType()) {
     Status error;
     rhs = rhs->Dereference(error);
+    if (error.Fail())
+      return error.ToError();
   }
 
   if (type.IsInteger()) {
-    if (rhs->GetCompilerType().IsPointerType()
-        || rhs->GetCompilerType().IsNullPtrType()) {
-      m_result = rhs->CastToBasicType(type);
-    } else {
-      CompilerType base_type = type.IsTypedefType() ? type.GetTypedefedType()
-                               : type;
-      CompilerType rhs_base_type = rhs->GetCompilerType().IsTypedefType() ?
-                                   rhs->GetCompilerType().GetTypedefedType() :
-                                   rhs->GetCompilerType();
-      assert(base_type.CompareTypes(rhs_base_type) &&
-             "invalid ast: operands should have the same type");
-      // Cast value to handle type aliases.
-      lldb::ValueObjectSP rhs_sp(GetDynamicOrSyntheticValue(rhs));
-      m_result = lldb::ValueObjectSP(rhs_sp->Cast(type));
-    }
-  } else if (type.IsEnumerationType()) {
+    if (rhs->GetCompilerType().IsPointerType() ||
+        rhs->GetCompilerType().IsNullPtrType())
+      return rhs->CastToBasicType(type);
+
     CompilerType base_type = type.IsTypedefType() ? type.GetTypedefedType()
                              : type;
     CompilerType rhs_base_type = rhs->GetCompilerType().IsTypedefType() ?
@@ -841,8 +1146,23 @@ void DILInterpreter::Visit(const CxxReinterpretCastNode* node) {
            "invalid ast: operands should have the same type");
     // Cast value to handle type aliases.
     lldb::ValueObjectSP rhs_sp(GetDynamicOrSyntheticValue(rhs));
-    m_result = lldb::ValueObjectSP(rhs_sp->Cast(type));
-  } else if (type.IsPointerType()) {
+    return lldb::ValueObjectSP(rhs_sp->Cast(type));
+  }
+
+  if (type.IsEnumerationType()) {
+    CompilerType base_type =
+        type.IsTypedefType() ? type.GetTypedefedType() : type;
+    CompilerType rhs_base_type = rhs->GetCompilerType().IsTypedefType()
+                                     ? rhs->GetCompilerType().GetTypedefedType()
+                                     : rhs->GetCompilerType();
+    assert(base_type.CompareTypes(rhs_base_type) &&
+           "invalid ast: operands should have the same type");
+    // Cast value to handle type aliases.
+    lldb::ValueObjectSP rhs_sp(GetDynamicOrSyntheticValue(rhs));
+    return lldb::ValueObjectSP(rhs_sp->Cast(type));
+  }
+
+  if (type.IsPointerType()) {
     assert((rhs->GetCompilerType().IsInteger() ||
             rhs->GetCompilerType().IsEnumerationType() ||
             rhs->GetCompilerType().IsPointerType() ||
@@ -853,21 +1173,21 @@ void DILInterpreter::Visit(const CxxReinterpretCastNode* node) {
                     : rhs->GetValueAsUnsigned(0);
     llvm::StringRef name = "result";
     ExecutionContext exe_ctx(m_target.get(), false);
-    m_result =
-        ValueObject::CreateValueObjectFromAddress(name, addr, exe_ctx,
-                                                  type,
-                                                  /* do_deref */ false);
-  } else if (type.IsReferenceType()) {
-    lldb::ValueObjectSP rhs_sp(GetDynamicOrSyntheticValue(rhs));
-    m_result =
-        lldb::ValueObjectSP(rhs_sp->Cast(type.GetNonReferenceType()));
-  } else {
-    assert(false && "invalid ast: unexpected reinterpret_cast kind");
-    m_result = lldb::ValueObjectSP();
+    return ValueObject::CreateValueObjectFromAddress(name, addr, exe_ctx, type,
+                                                     /* do_deref */ false);
   }
+
+  if (type.IsReferenceType()) {
+    lldb::ValueObjectSP rhs_sp(GetDynamicOrSyntheticValue(rhs));
+    return lldb::ValueObjectSP(rhs_sp->Cast(type.GetNonReferenceType()));
+  }
+
+  Status error("invalid ast: unexpected reinterpret_cast kind");
+  return error.ToError();
 }
 
-void DILInterpreter::Visit(const MemberOfNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const MemberOfNode *node) {
   // TODO: Implement address-of elision for member-of:
   //
   //  &(*ptr).foo -> (ptr + foo_offset)
@@ -877,39 +1197,51 @@ void DILInterpreter::Visit(const MemberOfNode* node) {
   // for members from non-virtual bases.
 
   Status error;
-  lldb::ValueObjectSP base = DILEvalNode(node->base());
-  if (!base) {
-    return;
+  auto base_or_err = DILEvalNode(node->base());
+  if (!base_or_err) {
+    return base_or_err;
   }
+  lldb::ValueObjectSP base = *base_or_err;
 
   if (node->valobj()) {
-    m_result = node->valobj()->GetSP();
-  } else {
-    if (base->GetCompilerType().IsReferenceType())
-      base = base->Dereference(error);
-    m_result = EvaluateMemberOf(base, node->member_index(),
-                                node->is_synthetic(),
-                                node->is_dynamic());
+    return node->valobj()->GetSP();
   }
+
+  if (base->GetCompilerType().IsReferenceType()) {
+    base = base->Dereference(error);
+    if (error.Fail())
+      return error.ToError();
+  }
+  return EvaluateMemberOf(base, node->member_index(), node->is_synthetic(),
+                          node->is_dynamic());
 }
 
-void DILInterpreter::Visit(const ArraySubscriptNode* node) {
-  auto base = DILEvalNode(node->base());
-  if (!base) {
-    return;
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const ArraySubscriptNode *node) {
+  auto base_or_err = DILEvalNode(node->base());
+  if (!base_or_err) {
+    return base_or_err;
   }
-  auto index = DILEvalNode(node->index());
-  if (!index) {
-    return;
+  lldb::ValueObjectSP base = *base_or_err;
+  auto index_or_err = DILEvalNode(node->index());
+  if (!index_or_err) {
+    return index_or_err;
   }
+  lldb::ValueObjectSP index = *index_or_err;
 
   // Check to see if either the base or the index are references; if they
   // are, dereference them.
   Status error;
-  if (base->GetCompilerType().IsReferenceType())
+  if (base->GetCompilerType().IsReferenceType()) {
     base = base->Dereference(error);
-  if (index->GetCompilerType().IsReferenceType())
+    if (error.Fail())
+      return error.ToError();
+  }
+  if (index->GetCompilerType().IsReferenceType()) {
     index = index->Dereference(error);
+    if (error.Fail())
+      return error.ToError();
+  }
 
   // Check to see if 'base' has a synthetic value; if so, try using that.
   if (base->HasSyntheticValue()) {
@@ -921,8 +1253,7 @@ void DILInterpreter::Visit(const ArraySubscriptNode* node) {
         lldb::ValueObjectSP child_valobj_sp =
             synthetic->GetChildAtIndex(child_idx);
         if (child_valobj_sp) {
-          m_result = child_valobj_sp;
-          return;
+          return child_valobj_sp;
         }
       }
     }
@@ -934,14 +1265,16 @@ void DILInterpreter::Visit(const ArraySubscriptNode* node) {
   if (synthetic) {
     uint32_t num_children = synthetic->GetNumChildrenIgnoringErrors();
     if (index->GetValueAsSigned(0) >= num_children) {
-      SetError(ErrorCode::kSubscriptOutOfRange,
-               llvm::formatv("array index {0} is not valid for \"({1}) {2}\"",
-                             index->GetValueAsSigned(0),
-                             base->GetTypeName().AsCString("<invalid type>"),
-                             base->GetName().AsCString()),
-               node->GetLocation());
-      m_result = lldb::ValueObjectSP();
-      return;
+      Status error = Status(
+          (uint32_t)ErrorCode::kSubscriptOutOfRange, lldb::eErrorTypeGeneric,
+          FormatDiagnostics(
+              m_expr,
+              llvm::formatv("array index {0} is not valid for \"({1}) {2}\"",
+                            index->GetValueAsSigned(0),
+                            base->GetTypeName().AsCString("<invalid type>"),
+                            base->GetName().AsCString()),
+              node->GetLocation()));
+      return error.ToError();
     }
   }
 
@@ -968,69 +1301,80 @@ void DILInterpreter::Visit(const ArraySubscriptNode* node) {
   // pending address-of operation as well.
   if (flow_analysis() && flow_analysis()->AddressOfIsPending()) {
     flow_analysis()->DiscardAddressOf();
-    m_result = value;
-  } else {
-    Status error;
-    m_result = value->Dereference(error);
+    return value;
   }
+
+  lldb::ValueObjectSP val2 = value->Dereference(error);
+  if (error.Fail())
+    return error.ToError();
+  return val2;
 }
 
-void DILInterpreter::Visit(const BinaryOpNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const BinaryOpNode *node) {
   // Short-circuit logical operators.
   if (node->kind() == BinaryOpKind::LAnd || node->kind() == BinaryOpKind::LOr) {
     Status error;
-    auto lhs = DILEvalNode(node->lhs());
-    if (!lhs) {
-      return;
+    auto lhs_or_err = DILEvalNode(node->lhs());
+    if (!lhs_or_err) {
+      return lhs_or_err;
     }
-    if (lhs->GetCompilerType().IsReferenceType())
+    lldb::ValueObjectSP lhs = *lhs_or_err;
+    if (lhs->GetCompilerType().IsReferenceType()) {
       lhs = lhs->Dereference(error);
+      if (error.Fail())
+        return error.ToError();
+    }
     assert(lhs->GetCompilerType().IsContextuallyConvertibleToBool() &&
            "invalid ast: must be convertible to bool");
 
     // For "&&" break if LHS is "false", for "||" if LHS is "true".
     auto lvalue_or_err = lhs->GetValueAsBool();
     if (!lvalue_or_err)
-      return;
+      return lvalue_or_err.takeError();
 
     bool lhs_val = *lvalue_or_err;
     bool break_early =
         (node->kind() == BinaryOpKind::LAnd) ? !lhs_val : lhs_val;
 
     if (break_early) {
-      m_result = ValueObject::CreateValueObjectFromBool(m_target, lhs_val, "result");
-      return;
+      return ValueObject::CreateValueObjectFromBool(m_target, lhs_val,
+                                                    "result");
     }
 
     // Breaking early didn't happen, evaluate the RHS and use it as a result.
-    auto rhs = DILEvalNode(node->rhs());
-    if (!rhs) {
-      return;
+    auto rhs_or_err = DILEvalNode(node->rhs());
+    if (!rhs_or_err) {
+      return rhs_or_err;
     }
-    if (rhs->GetCompilerType().IsReferenceType())
+    lldb::ValueObjectSP rhs = *rhs_or_err;
+    if (rhs->GetCompilerType().IsReferenceType()) {
       rhs = rhs->Dereference(error);
+      if (error.Fail())
+        return error.ToError();
+    }
     assert(rhs->GetCompilerType().IsContextuallyConvertibleToBool() &&
            "invalid ast: must be convertible to bool");
 
     auto rvalue_or_err = rhs->GetValueAsBool();
     if (!rvalue_or_err)
-      return;
+      return rvalue_or_err.takeError();
 
-    m_result = ValueObject::CreateValueObjectFromBool(m_target,
-                                                      *rvalue_or_err,
-                                                      "result");
-    return;
+    return ValueObject::CreateValueObjectFromBool(m_target, *rvalue_or_err,
+                                                  "result");
   }
 
   // All other binary operations require evaluating both operands.
-  auto lhs = DILEvalNode(node->lhs());
-  if (!lhs) {
-    return;
+  auto lhs_or_err = DILEvalNode(node->lhs());
+  if (!lhs_or_err) {
+    return lhs_or_err;
   }
-  auto rhs = DILEvalNode(node->rhs());
-  if (!rhs) {
-    return;
+  lldb::ValueObjectSP lhs = *lhs_or_err;
+  auto rhs_or_err = DILEvalNode(node->rhs());
+  if (!rhs_or_err) {
+    return rhs_or_err;
   }
+  lldb::ValueObjectSP rhs = *rhs_or_err;
 
   // For math operations, be sure to dereference the operands.
   if ((node->kind() == BinaryOpKind::Add)
@@ -1039,39 +1383,39 @@ void DILInterpreter::Visit(const BinaryOpNode* node) {
       || (node->kind() == BinaryOpKind::Div)
       || (node->kind() == BinaryOpKind::Rem)) {
     Status error;
-    if (lhs->GetCompilerType().IsReferenceType())
+    if (lhs->GetCompilerType().IsReferenceType()) {
       lhs = lhs->Dereference(error);
-    if (rhs->GetCompilerType().IsReferenceType())
+      if (error.Fail())
+        return error.ToError();
+    }
+    if (rhs->GetCompilerType().IsReferenceType()) {
       rhs = rhs->Dereference(error);
+      if (error.Fail())
+        return error.ToError();
+    }
   }
 
   switch (node->kind()) {
     case BinaryOpKind::Add:
-      m_result = EvaluateBinaryAddition(lhs, rhs);
-      return;
+      return EvaluateBinaryAddition(lhs, rhs);
     case BinaryOpKind::Sub:
       // The result type of subtraction is required because it holds the
       // correct "ptrdiff_t" type in the case of subtracting two pointers.
-      m_result = EvaluateBinarySubtraction(lhs, rhs, node->GetDereferencedResultType());
-      return;
+      return EvaluateBinarySubtraction(lhs, rhs,
+                                       node->GetDereferencedResultType());
     case BinaryOpKind::Mul:
-      m_result = EvaluateBinaryMultiplication(lhs, rhs);
-      return;
+      return EvaluateBinaryMultiplication(lhs, rhs);
     case BinaryOpKind::Div:
-      m_result = EvaluateBinaryDivision(lhs, rhs);
-      return;
+      return EvaluateBinaryDivision(lhs, rhs);
     case BinaryOpKind::Rem:
-      m_result = EvaluateBinaryRemainder(lhs, rhs);
-      return;
+      return EvaluateBinaryRemainder(lhs, rhs);
     case BinaryOpKind::And:
     case BinaryOpKind::Or:
     case BinaryOpKind::Xor:
-      m_result = EvaluateBinaryBitwise(node->kind(), lhs, rhs);
-      return;
+      return EvaluateBinaryBitwise(node->kind(), lhs, rhs);
     case BinaryOpKind::Shl:
     case BinaryOpKind::Shr:
-      m_result = EvaluateBinaryShift(node->kind(), lhs, rhs);
-      return;
+      return EvaluateBinaryShift(node->kind(), lhs, rhs);
 
     // Comparison operations.
     case BinaryOpKind::EQ:
@@ -1080,61 +1424,56 @@ void DILInterpreter::Visit(const BinaryOpNode* node) {
     case BinaryOpKind::LE:
     case BinaryOpKind::GT:
     case BinaryOpKind::GE:
-      m_result = EvaluateComparison(node->kind(), lhs, rhs);
-      return;
+      return EvaluateComparison(node->kind(), lhs, rhs);
 
     case BinaryOpKind::Assign:
-      m_result = EvaluateAssignment(lhs, rhs);
-      return;
-
+      return EvaluateAssignment(lhs, rhs);
     case BinaryOpKind::AddAssign:
-      m_result = EvaluateBinaryAddAssign(lhs, rhs);
-      return;
+      return EvaluateBinaryAddAssign(lhs, rhs);
     case BinaryOpKind::SubAssign:
-      m_result = EvaluateBinarySubAssign(lhs, rhs);
-      return;
+      return EvaluateBinarySubAssign(lhs, rhs);
     case BinaryOpKind::MulAssign:
-      m_result = EvaluateBinaryMulAssign(lhs, rhs);
-      return;
+      return EvaluateBinaryMulAssign(lhs, rhs);
     case BinaryOpKind::DivAssign:
-      m_result = EvaluateBinaryDivAssign(lhs, rhs);
-      return;
+      return EvaluateBinaryDivAssign(lhs, rhs);
     case BinaryOpKind::RemAssign:
-      m_result = EvaluateBinaryRemAssign(lhs, rhs);
-      return;
+      return EvaluateBinaryRemAssign(lhs, rhs);
 
     case BinaryOpKind::AndAssign:
     case BinaryOpKind::OrAssign:
     case BinaryOpKind::XorAssign:
-      m_result = EvaluateBinaryBitwiseAssign(node->kind(), lhs, rhs);
-      return;
+      return EvaluateBinaryBitwiseAssign(node->kind(), lhs, rhs);
     case BinaryOpKind::ShlAssign:
     case BinaryOpKind::ShrAssign:
-      m_result = EvaluateBinaryShiftAssign(node->kind(), lhs, rhs,
-                                          node->comp_assign_type());
-      return;
+      return EvaluateBinaryShiftAssign(node->kind(), lhs, rhs,
+                                       node->comp_assign_type());
 
     default:
       break;
   }
 
   // Unsupported/invalid operation.
-  assert(false && "invalid ast: unexpected binary operator");
-  m_result = lldb::ValueObjectSP();
+  Status error("invalid ast: unexpected binary operator");
+  return error.ToError();
 }
 
-void DILInterpreter::Visit(const UnaryOpNode* node) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const UnaryOpNode *node) {
   FlowAnalysis rhs_flow(
       /* address_of_is_pending */ node->kind() == UnaryOpKind::AddrOf);
 
   Status error;
-  auto rhs = DILEvalNode(node->rhs(), &rhs_flow);
-  if (!rhs) {
-    return;
+  auto rhs_or_err = DILEvalNode(node->rhs(), &rhs_flow);
+  if (!rhs_or_err) {
+    return rhs_or_err;
   }
+  lldb::ValueObjectSP rhs = *rhs_or_err;
 
-  if (rhs->GetCompilerType().IsReferenceType())
+  if (rhs->GetCompilerType().IsReferenceType()) {
     rhs = rhs->Dereference(error);
+    if (error.Fail())
+      return error.ToError();
+  }
 
   switch (node->kind()) {
     case UnaryOpKind::Deref:
@@ -1143,71 +1482,69 @@ void DILInterpreter::Visit(const UnaryOpNode* node) {
             rhs->GetDynamicValue(m_default_dynamic);
         if (dynamic_rhs)
           rhs = dynamic_rhs;
-      }
-      if (rhs->GetCompilerType().IsPointerType())
-        m_result = EvaluateDereference(rhs);
-      else {
+
+        if (rhs->GetCompilerType().IsPointerType())
+          return EvaluateDereference(rhs);
         lldb::ValueObjectSP child_sp = rhs->Dereference(error);
         if (error.Success())
           rhs = child_sp;
-        m_result = rhs;
-      }
-      return;
 
-    case UnaryOpKind::AddrOf:
+        return rhs;
+    }
+    case UnaryOpKind::AddrOf: {
       // If the address-of operation wasn't cancelled during the evaluation of
       // RHS (e.g. because of the address-of-a-dereference elision), apply it
       // here.
       if (rhs_flow.AddressOfIsPending()) {
         Status error;
-        m_result = rhs->AddressOf(error);
-      } else {
-        m_result = rhs;
+        lldb::ValueObjectSP value = rhs->AddressOf(error);
+        if (error.Fail())
+          return error.ToError();
+        return value;
       }
-      return;
+      return rhs;
+    }
     case UnaryOpKind::Plus:
-      m_result = rhs;
-      return;
+      return rhs;
     case UnaryOpKind::Minus:
-      m_result = EvaluateUnaryMinus(rhs);
-      return;
+      return EvaluateUnaryMinus(rhs);
     case UnaryOpKind::LNot:
-      m_result = EvaluateUnaryNegation(rhs);
-      return;
+      return EvaluateUnaryNegation(rhs);
     case UnaryOpKind::Not:
-      m_result = EvaluateUnaryBitwiseNot(rhs);
-      return;
+      return EvaluateUnaryBitwiseNot(rhs);
     case UnaryOpKind::PreInc:
-      m_result = EvaluateUnaryPrefixIncrement(rhs);
-      return;
+      return EvaluateUnaryPrefixIncrement(rhs);
     case UnaryOpKind::PreDec:
-      m_result = EvaluateUnaryPrefixDecrement(rhs);
-      return;
-    case UnaryOpKind::PostInc:
+      return EvaluateUnaryPrefixDecrement(rhs);
+    case UnaryOpKind::PostInc: {
       // In postfix inc/dec the result is the original value.
-      m_result = rhs->Clone(ConstString("cloned-object"));
+      lldb::ValueObjectSP val2 = rhs->Clone(ConstString("cloned-object"));
       EvaluateUnaryPrefixIncrement(rhs);
-      return;
-    case UnaryOpKind::PostDec:
+      return val2;
+    }
+    case UnaryOpKind::PostDec: {
       // In postfix inc/dec the result is the original value.
-      m_result = rhs->Clone(ConstString("cloned-object"));
+      lldb::ValueObjectSP val2 = rhs->Clone(ConstString("cloned-object"));
       EvaluateUnaryPrefixDecrement(rhs);
-      return;
+      return val2;
+    }
 
     default:
       break;
   }
 
   // Unsupported/invalid operation.
-  assert(false && "invalid ast: unexpected binary operator");
-  m_result = lldb::ValueObjectSP();
+  Status error2("invalid ast: unexpected binary operator");
+  return error2.ToError();
 }
 
-void DILInterpreter::Visit(const TernaryOpNode* node) {
-  auto cond = DILEvalNode(node->cond());
-  if (!cond) {
-    return;
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::Visit(const TernaryOpNode *node) {
+  auto cond_or_err = DILEvalNode(node->cond());
+  if (!cond_or_err) {
+    return cond_or_err;
   }
+  lldb::ValueObjectSP cond = *cond_or_err;
   assert(cond->GetCompilerType().IsContextuallyConvertibleToBool() &&
          "invalid ast: must be convertible to bool");
 
@@ -1217,15 +1554,16 @@ void DILInterpreter::Visit(const TernaryOpNode* node) {
   auto value_or_err = cond->GetValueAsBool();
   if (value_or_err) {
     if (*value_or_err)
-      m_result = DILEvalNode(node->lhs(), flow_analysis());
-    else
-      m_result = DILEvalNode(node->rhs(), flow_analysis());
+      return DILEvalNode(node->lhs(), flow_analysis());
+
+    return DILEvalNode(node->rhs(), flow_analysis());
   }
+  return value_or_err.takeError();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateComparison(BinaryOpKind kind,
-                                                       lldb::ValueObjectSP lhs,
-                                                       lldb::ValueObjectSP rhs) {
+lldb::ValueObjectSP Interpreter::EvaluateComparison(BinaryOpKind kind,
+                                                    lldb::ValueObjectSP lhs,
+                                                    lldb::ValueObjectSP rhs) {
   // Evaluate arithmetic operation for two integral values.
   if (lhs->GetCompilerType().IsInteger() && rhs->GetCompilerType().IsInteger()) {
     llvm::Expected<llvm::APSInt> l = lhs->GetValueAsAPSInt();
@@ -1273,8 +1611,7 @@ lldb::ValueObjectSP DILInterpreter::EvaluateComparison(BinaryOpKind kind,
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateDereference(lldb::ValueObjectSP rhs)
-{
+lldb::ValueObjectSP Interpreter::EvaluateDereference(lldb::ValueObjectSP rhs) {
   // If rhs is a reference, dereference it first.
   Status error;
   if (rhs->GetCompilerType().IsReferenceType())
@@ -1306,8 +1643,7 @@ lldb::ValueObjectSP DILInterpreter::EvaluateDereference(lldb::ValueObjectSP rhs)
   return value->Dereference(error);
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateUnaryMinus(lldb::ValueObjectSP rhs)
-{
+lldb::ValueObjectSP Interpreter::EvaluateUnaryMinus(lldb::ValueObjectSP rhs) {
   assert((rhs->GetCompilerType().IsInteger() || rhs->GetCompilerType().IsFloat())
          && "invalid ast: must be an arithmetic type");
 
@@ -1335,9 +1671,8 @@ lldb::ValueObjectSP DILInterpreter::EvaluateUnaryMinus(lldb::ValueObjectSP rhs)
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateUnaryNegation(
-    lldb::ValueObjectSP rhs)
-{
+lldb::ValueObjectSP
+Interpreter::EvaluateUnaryNegation(lldb::ValueObjectSP rhs) {
   assert(rhs->GetCompilerType().IsContextuallyConvertibleToBool() &&
          "invalid ast: must be convertible to bool");
   auto value_or_err = rhs->GetValueAsBool();
@@ -1349,8 +1684,8 @@ lldb::ValueObjectSP DILInterpreter::EvaluateUnaryNegation(
     return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateUnaryBitwiseNot(
-    lldb::ValueObjectSP rhs) {
+lldb::ValueObjectSP
+Interpreter::EvaluateUnaryBitwiseNot(lldb::ValueObjectSP rhs) {
   assert(rhs->GetCompilerType().IsInteger() && "invalid ast: must be an integer");
   auto value_or_err = rhs->GetValueAsAPSInt();
   if (value_or_err) {
@@ -1363,9 +1698,8 @@ lldb::ValueObjectSP DILInterpreter::EvaluateUnaryBitwiseNot(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateUnaryPrefixIncrement(
-    lldb::ValueObjectSP rhs)
-{
+lldb::ValueObjectSP
+Interpreter::EvaluateUnaryPrefixIncrement(lldb::ValueObjectSP rhs) {
   assert((rhs->GetCompilerType().IsInteger() || rhs->GetCompilerType().IsFloat()
           || rhs->GetCompilerType().IsPointerType()) &&
          "invalid ast: must be either arithmetic type or pointer");
@@ -1403,7 +1737,7 @@ lldb::ValueObjectSP DILInterpreter::EvaluateUnaryPrefixIncrement(
             rhs->GetCompilerType().GetPointeeType().GetByteSize(
                 rhs->GetTargetSP().get()))
       byte_size = temp.value();
-    v += byte_size;;  // Do the increment.
+    v += byte_size; // Do the increment.
 
     rhs->SetValueFromInteger(llvm::APInt(64, v), status);
     if (status.Success())
@@ -1413,8 +1747,8 @@ lldb::ValueObjectSP DILInterpreter::EvaluateUnaryPrefixIncrement(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateUnaryPrefixDecrement(
-    lldb::ValueObjectSP rhs) {
+lldb::ValueObjectSP
+Interpreter::EvaluateUnaryPrefixDecrement(lldb::ValueObjectSP rhs) {
   assert((rhs->GetCompilerType().IsInteger() ||
           rhs->GetCompilerType().IsFloat() ||
           rhs->GetCompilerType().IsPointerType()) &&
@@ -1463,10 +1797,9 @@ lldb::ValueObjectSP DILInterpreter::EvaluateUnaryPrefixDecrement(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryAddition(
-    lldb::ValueObjectSP lhs,
-    lldb::ValueObjectSP rhs)
-{
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinaryAddition(lldb::ValueObjectSP lhs,
+                                    lldb::ValueObjectSP rhs) {
   // Addition of two arithmetic types.
   if (lhs->GetCompilerType().IsScalarType()
       && rhs->GetCompilerType().IsScalarType()) {
@@ -1493,17 +1826,16 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryAddition(
   if (ptr->GetValueAsUnsigned(0) == 0 && offset->GetValueAsUnsigned(0) != 0) {
     // Binary addition with null pointer causes mismatches between LLDB and
     // lldb-eval if the offset different than zero.
-    SetUbStatus(m_error, ErrorCode::kUBNullPtrArithmetic);
+    return SetUbStatus(ErrorCode::kUBNullPtrArithmetic).ToError();
   }
 
   return PointerAdd(ptr, offset->GetValueAsUnsigned(0));
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinarySubtraction(
-    lldb::ValueObjectSP lhs,
-    lldb::ValueObjectSP rhs,
-    CompilerType result_type)
-{
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinarySubtraction(lldb::ValueObjectSP lhs,
+                                       lldb::ValueObjectSP rhs,
+                                       CompilerType result_type) {
   if (lhs->GetCompilerType().IsScalarType()
       && rhs->GetCompilerType().IsScalarType()) {
     assert(lhs->GetCompilerType().CompareTypes(rhs->GetCompilerType()) &&
@@ -1544,7 +1876,7 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinarySubtraction(
     // If address difference isn't divisible by pointee size then performing
     // the operation is undefined behaviour. Note: mismatches were encountered
     // only for negative difference (diff < 0).
-    SetUbStatus(m_error, ErrorCode::kUBInvalidPtrDiff);
+    return SetUbStatus(ErrorCode::kUBInvalidPtrDiff).ToError();
   }
 
   diff /= static_cast<int64_t>(item_size);
@@ -1561,8 +1893,9 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinarySubtraction(
                                                 result_type);
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryMultiplication(
-    lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs) {
+lldb::ValueObjectSP
+Interpreter::EvaluateBinaryMultiplication(lldb::ValueObjectSP lhs,
+                                          lldb::ValueObjectSP rhs) {
   assert((lhs->GetCompilerType().IsScalarType() &&
           lhs->GetCompilerType().CompareTypes(rhs->GetCompilerType())) &&
          "invalid ast: operands must be arithmetic and have the same type");
@@ -1571,8 +1904,9 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryMultiplication(
                               lhs->GetCompilerType().GetCanonicalType());
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryDivision(
-    lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinaryDivision(lldb::ValueObjectSP lhs,
+                                    lldb::ValueObjectSP rhs) {
   assert((lhs->GetCompilerType().IsScalarType() &&
           lhs->GetCompilerType().CompareTypes(rhs->GetCompilerType())) &&
          "invalid ast: operands must be arithmetic and have the same type");
@@ -1583,24 +1917,23 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryDivision(
     //
     //  warning: division by zero is undefined [-Wdivision-by-zero]
     //
-    SetUbStatus(m_error, ErrorCode::kUBDivisionByZero);
+    return SetUbStatus(ErrorCode::kUBDivisionByZero).ToError();
 
     return rhs;
   }
 
   if (rhs->GetCompilerType().IsInteger() && IsInvalidDivisionByMinusOne(lhs, rhs))
   {
-    SetUbStatus(m_error, ErrorCode::kUBDivisionByMinusOne);
+    return SetUbStatus(ErrorCode::kUBDivisionByMinusOne).ToError();
   }
 
   return EvaluateArithmeticOp(m_target, BinaryOpKind::Div, lhs, rhs,
                               lhs->GetCompilerType().GetCanonicalType());
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryRemainder(
-    lldb::ValueObjectSP lhs,
-    lldb::ValueObjectSP rhs)
-{
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinaryRemainder(lldb::ValueObjectSP lhs,
+                                     lldb::ValueObjectSP rhs) {
   assert((lhs->GetCompilerType().IsInteger()
           && lhs->GetCompilerType().CompareTypes(rhs->GetCompilerType()))
          && "invalid ast: operands must be integers and have the same type");
@@ -1610,24 +1943,22 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryRemainder(
     //
     //  warning: remainder by zero is undefined [-Wdivision-by-zero]
     //
-    SetUbStatus(m_error, ErrorCode::kUBDivisionByZero);
+    return SetUbStatus(ErrorCode::kUBDivisionByZero).ToError();
 
     return rhs;
   }
 
   if (IsInvalidDivisionByMinusOne(lhs, rhs)) {
-    SetUbStatus(m_error, ErrorCode::kUBDivisionByMinusOne);
+    return SetUbStatus(ErrorCode::kUBDivisionByMinusOne).ToError();
   }
 
   return EvaluateArithmeticOpInteger(m_target, BinaryOpKind::Rem, lhs, rhs,
                                      lhs->GetCompilerType());
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryBitwise(
-    BinaryOpKind kind,
-    lldb::ValueObjectSP lhs,
-    lldb::ValueObjectSP rhs)
-{
+lldb::ValueObjectSP
+Interpreter::EvaluateBinaryBitwise(BinaryOpKind kind, lldb::ValueObjectSP lhs,
+                                   lldb::ValueObjectSP rhs) {
   assert((lhs->GetCompilerType().IsInteger()
           && lhs->GetCompilerType().CompareTypes(rhs->GetCompilerType()))
          &&"invalid ast: operands must be integers and have the same type");
@@ -1639,10 +1970,9 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryBitwise(
                                      lhs->GetCompilerType().GetCanonicalType());
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryShift(BinaryOpKind kind,
-                                                        lldb::ValueObjectSP lhs,
-                                                        lldb::ValueObjectSP rhs)
-{
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinaryShift(BinaryOpKind kind, lldb::ValueObjectSP lhs,
+                                 lldb::ValueObjectSP rhs) {
   assert(lhs->GetCompilerType().IsInteger() &&
          rhs->GetCompilerType().IsInteger() &&
          "invalid ast: operands must be integers");
@@ -1657,15 +1987,15 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryShift(BinaryOpKind kind,
   llvm::Expected<llvm::APSInt> r = rhs->GetValueAsAPSInt();
   if (r && (r->isNegative() ||
             (rhs->GetValueAsUnsigned(0) >= lhs_byte_size * CHAR_BIT))) {
-    SetUbStatus(m_error, ErrorCode::kUBInvalidShift);
+    return SetUbStatus(ErrorCode::kUBInvalidShift).ToError();
   }
 
   return EvaluateArithmeticOpInteger(m_target, kind, lhs, rhs,
                                      lhs->GetCompilerType());
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateAssignment(lldb::ValueObjectSP lhs,
-                                                       lldb::ValueObjectSP rhs) {
+lldb::ValueObjectSP Interpreter::EvaluateAssignment(lldb::ValueObjectSP lhs,
+                                                    lldb::ValueObjectSP rhs) {
   assert(lhs->GetCompilerType().CompareTypes(rhs->GetCompilerType()) &&
          "invalid ast: operands must have the same type");
 
@@ -1676,22 +2006,28 @@ lldb::ValueObjectSP DILInterpreter::EvaluateAssignment(lldb::ValueObjectSP lhs,
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryAddAssign(
-    lldb::ValueObjectSP lhs,
-    lldb::ValueObjectSP rhs) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinaryAddAssign(lldb::ValueObjectSP lhs,
+                                     lldb::ValueObjectSP rhs) {
   lldb::ValueObjectSP ret;
 
   if (lhs->GetCompilerType().IsPointerType()) {
     assert(rhs->GetCompilerType().IsInteger() &&
            "invalid ast: rhs must be an integer");
-    ret = EvaluateBinaryAddition(lhs, rhs);
+    auto ret_or_err = EvaluateBinaryAddition(lhs, rhs);
+    if (!ret_or_err)
+      return ret_or_err;
+    ret = *ret_or_err;
   } else {
     assert(lhs->GetCompilerType().IsScalarType()
            && "invalid ast: lhs must be an arithmetic type");
     assert(rhs->GetCompilerType().IsBasicType() &&
            "invalid ast: rhs must be a basic type");
     ret = lhs->CastToBasicType(rhs->GetCompilerType());
-    ret = EvaluateBinaryAddition(ret, rhs);
+    auto ret_or_err = EvaluateBinaryAddition(ret, rhs);
+    if (!ret_or_err)
+      return ret_or_err;
+    ret = *ret_or_err;
     ret = ret->CastToBasicType(lhs->GetCompilerType());
   }
 
@@ -1702,23 +2038,30 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryAddAssign(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinarySubAssign(
-    lldb::ValueObjectSP lhs,
-    lldb::ValueObjectSP rhs)
-{
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinarySubAssign(lldb::ValueObjectSP lhs,
+                                     lldb::ValueObjectSP rhs) {
   lldb::ValueObjectSP ret;
 
   if (lhs->GetCompilerType().IsPointerType()) {
     assert(rhs->GetCompilerType().IsInteger() &&
            "invalid ast: rhs must be an integer");
-    ret = EvaluateBinarySubtraction(lhs, rhs, lhs->GetCompilerType());
+    auto ret_or_err =
+        EvaluateBinarySubtraction(lhs, rhs, lhs->GetCompilerType());
+    if (!ret_or_err)
+      return ret_or_err;
+    ret = *ret_or_err;
   } else {
     assert(lhs->GetCompilerType().IsScalarType()
            && "invalid ast: lhs must be an arithmetic type");
     assert(rhs->GetCompilerType().IsBasicType() &&
            "invalid ast: rhs must be a basic type");
     ret = lhs->CastToBasicType(rhs->GetCompilerType());
-    ret = EvaluateBinarySubtraction(ret, rhs, ret->GetCompilerType());
+    auto ret_or_err =
+        EvaluateBinarySubtraction(ret, rhs, ret->GetCompilerType());
+    if (!ret_or_err)
+      return ret_or_err;
+    ret = *ret_or_err;
     ret = ret->CastToBasicType(lhs->GetCompilerType());
   }
 
@@ -1729,8 +2072,9 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinarySubAssign(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryMulAssign(
-    lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs) {
+lldb::ValueObjectSP
+Interpreter::EvaluateBinaryMulAssign(lldb::ValueObjectSP lhs,
+                                     lldb::ValueObjectSP rhs) {
   assert(lhs->GetCompilerType().IsScalarType()
          && "invalid ast: lhs must be an arithmetic type");
   assert(rhs->GetCompilerType().IsBasicType()
@@ -1747,15 +2091,19 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryMulAssign(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryDivAssign(
-    lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinaryDivAssign(lldb::ValueObjectSP lhs,
+                                     lldb::ValueObjectSP rhs) {
   assert(lhs->GetCompilerType().IsScalarType()
          && "invalid ast: lhs must be an arithmetic type");
   assert(rhs->GetCompilerType().IsBasicType()
          && "invalid ast: rhs must be a basic type");
 
   lldb::ValueObjectSP ret = lhs->CastToBasicType(rhs->GetCompilerType());
-  ret = EvaluateBinaryDivision(ret, rhs);
+  auto ret_or_err = EvaluateBinaryDivision(ret, rhs);
+  if (!ret_or_err)
+    return ret_or_err;
+  ret = *ret_or_err;
   ret = ret->CastToBasicType(lhs->GetCompilerType());
 
   Status status;
@@ -1765,8 +2113,9 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryDivAssign(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryRemAssign(
-    lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs) {
+llvm::Expected<lldb::ValueObjectSP>
+Interpreter::EvaluateBinaryRemAssign(lldb::ValueObjectSP lhs,
+                                     lldb::ValueObjectSP rhs) {
   assert(lhs->GetCompilerType().IsScalarType()
          && "invalid ast: lhs must be an arithmetic type");
   assert(rhs->GetCompilerType().IsBasicType()
@@ -1774,7 +2123,10 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryRemAssign(
 
   lldb::ValueObjectSP ret = lhs->CastToBasicType(rhs->GetCompilerType());
 
-  ret = EvaluateBinaryRemainder(ret, rhs);
+  auto ret_or_err = EvaluateBinaryRemainder(ret, rhs);
+  if (!ret_or_err)
+    return ret_or_err;
+  ret = *ret_or_err;
   ret = ret->CastToBasicType(lhs->GetCompilerType());
 
   Status status;
@@ -1784,9 +2136,8 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryRemAssign(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryBitwiseAssign(
-    BinaryOpKind kind, lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs)
-{
+lldb::ValueObjectSP Interpreter::EvaluateBinaryBitwiseAssign(
+    BinaryOpKind kind, lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs) {
   switch (kind) {
     case BinaryOpKind::AndAssign:
       kind = BinaryOpKind::And;
@@ -1817,12 +2168,9 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryBitwiseAssign(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::EvaluateBinaryShiftAssign(
-    BinaryOpKind kind,
-    lldb::ValueObjectSP lhs,
-    lldb::ValueObjectSP rhs,
-    CompilerType comp_assign_type)
-{
+llvm::Expected<lldb::ValueObjectSP> Interpreter::EvaluateBinaryShiftAssign(
+    BinaryOpKind kind, lldb::ValueObjectSP lhs, lldb::ValueObjectSP rhs,
+    CompilerType comp_assign_type) {
   switch (kind) {
     case BinaryOpKind::ShlAssign:
       kind = BinaryOpKind::Shl;
@@ -1842,7 +2190,10 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryShiftAssign(
          "invalid ast: comp_assign_type must be an integer");
 
   lldb::ValueObjectSP ret = lhs->CastToBasicType(comp_assign_type);
-  ret = EvaluateBinaryShift(kind, ret, rhs);
+  auto ret_or_err = EvaluateBinaryShift(kind, ret, rhs);
+  if (!ret_or_err)
+    return ret_or_err;
+  ret = *ret_or_err;
   ret = ret->CastToBasicType(lhs->GetCompilerType());
 
   Status status;
@@ -1852,8 +2203,8 @@ lldb::ValueObjectSP DILInterpreter::EvaluateBinaryShiftAssign(
   return lldb::ValueObjectSP();
 }
 
-lldb::ValueObjectSP DILInterpreter::PointerAdd(lldb::ValueObjectSP lhs,
-                                               int64_t offset) {
+lldb::ValueObjectSP Interpreter::PointerAdd(lldb::ValueObjectSP lhs,
+                                            int64_t offset) {
   uint64_t byte_size = 0;
   if (auto temp = lhs->GetCompilerType().GetPointeeType().GetByteSize(
           lhs->GetTargetSP().get()))
@@ -1867,9 +2218,8 @@ lldb::ValueObjectSP DILInterpreter::PointerAdd(lldb::ValueObjectSP lhs,
                                                     /* do_deref */ false);
 }
 
-lldb::ValueObjectSP DILInterpreter::ResolveContextVar(
-    const std::string& name) const
-{
+lldb::ValueObjectSP
+Interpreter::ResolveContextVar(const std::string &name) const {
   auto it = m_context_vars.find(name);
   return it != m_context_vars.end() ? it->second : lldb::ValueObjectSP();
 }

--- a/lldb/source/ValueObject/DILLexer.cpp
+++ b/lldb/source/ValueObject/DILLexer.cpp
@@ -12,38 +12,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/ValueObject/DILLexer.h"
-//#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSwitch.h"
 
 namespace lldb_private::dil {
-
-/*
-const llvm::StringMap<Token::Kind> Keywords = {
-    {"bool", Token::kw_bool},
-    {"char", Token::kw_char},
-    {"char16_t", Token::kw_char16_t},
-    {"char32_t", Token::kw_char32_t},
-    {"const", Token::kw_const},
-    {"double", Token::kw_double},
-    {"dynamic_cast", Token::kw_dynamic_cast},
-    {"false", Token::kw_false},
-    {"float", Token::kw_float},
-    {"int", Token::kw_int},
-    {"long", Token::kw_long},
-    {"namespace", Token::kw_namespace},
-    {"nullptr", Token::kw_nullptr},
-    {"reinterpret_cast", Token::kw_reinterpret_cast},
-    {"short", Token::kw_short},
-    {"signed", Token::kw_signed},
-    {"sizeof", Token::kw_sizeof},
-    {"static_cast", Token::kw_static_cast},
-    {"this", Token::kw_this},
-    {"true", Token::kw_true},
-    {"unsigned", Token::kw_unsigned},
-    {"void", Token::kw_void},
-    {"volatile", Token::kw_volatile},
-    {"wchar_t", Token::kw_wchar_t}};
-*/
 
 llvm::StringRef Token::GetTokenName(Kind kind) {
   switch (kind){
@@ -105,8 +76,6 @@ llvm::StringRef Token::GetTokenName(Kind kind) {
       return "sizeof";
     case Token::kw_static_cast:
       return "static_cast";
-    case Token::kw_this:
-      return "this";
     case Token::kw_true:
       return "true";
     case Token::kw_unsigned:
@@ -188,7 +157,7 @@ static std::optional<llvm::StringRef> IsNumber(llvm::StringRef expr,
   llvm::StringRef::iterator start = cur_pos;
   uint32_t length = 0;
   char prev_ch = 0;
-  dil::NumberKind kind = dil::NumberKind::eInteger;
+  // Possibly lexing an integer.
   if (*start == '.') {
     auto next_pos = start + 1;
     if (next_pos == expr.end() || !IsDigit(*next_pos))
@@ -198,7 +167,7 @@ static std::optional<llvm::StringRef> IsNumber(llvm::StringRef expr,
     ConsumeNumberBody(length, prev_ch, cur_pos, expr);
     // We're not at the end of the string, and we should be looking at a '.'
     if (*cur_pos == '.') {
-      kind = dil::NumberKind::eFloat;
+      // Lexing a floating point.
       prev_ch = *cur_pos;
       length++;
       cur_pos++;
@@ -225,15 +194,13 @@ llvm::Expected<DILLexer> DILLexer::Create(llvm::StringRef expr) {
   std::vector<Token> tokens;
   llvm::StringRef remainder = expr;
   do {
-    if (llvm::Expected<Token> t = Lex(expr, remainder)) {
+    if (llvm::Expected<Token> t = Lex(expr, remainder))
       tokens.push_back(std::move(*t));
-    } else {
+    else
       return t.takeError();
-    }
   } while (tokens.back().GetKind() != Token::eof);
   return DILLexer(expr, std::move(tokens));
 }
-
 
 llvm::Expected<Token> DILLexer::Lex(llvm::StringRef expr,
                                     llvm::StringRef &remainder) {
@@ -245,7 +212,7 @@ llvm::Expected<Token> DILLexer::Lex(llvm::StringRef expr,
   if (remainder.empty())
     return Token(Token::eof, "", (uint32_t)expr.size());
 
-  uint32_t position = cur_pos - expr.begin();;
+  uint32_t position = cur_pos - expr.begin();
   llvm::StringRef::iterator start = cur_pos;
   std::optional<llvm::StringRef> maybe_number = IsNumber(expr, remainder);
   if (maybe_number) {
@@ -255,32 +222,32 @@ llvm::Expected<Token> DILLexer::Lex(llvm::StringRef expr,
     std::optional<llvm::StringRef> maybe_word = IsWord(expr, remainder);
     if (maybe_word) {
       llvm::StringRef word = *maybe_word;
-      Token::Kind kind = llvm::StringSwitch<Token::Kind>(word)
-                            .Case("bool", Token::kw_bool)
-                            .Case("char", Token::kw_char)
-                            .Case("char16_t", Token::kw_char16_t)
-                            .Case("char32_t", Token::kw_char32_t)
-                            .Case("const", Token::kw_const)
-                            .Case("double", Token::kw_double)
-                            .Case("dynamic_cast", Token::kw_dynamic_cast)
-                            .Case("false", Token::kw_false)
-                            .Case("float", Token::kw_float)
-                            .Case("int", Token::kw_int)
-                            .Case("long", Token::kw_long)
-                            .Case("namespace", Token::kw_namespace)
-                            .Case("nullptr", Token::kw_nullptr)
-                            .Case("reinterpret_cast", Token::kw_reinterpret_cast)
-                            .Case("short", Token::kw_short)
-                            .Case("signed", Token::kw_signed)
-                            .Case("sizeof", Token::kw_sizeof)
-                            .Case("static_cast", Token::kw_static_cast)
-                            .Case("this", Token::kw_this)
-                            .Case("true", Token::kw_true)
-                            .Case("unsigned", Token::kw_unsigned)
-                            .Case("void", Token::kw_void)
-                            .Case("volatile", Token::kw_volatile)
-                            .Case("wchar_t", Token::kw_wchar_t)
-                            .Default(Token::identifier);
+      Token::Kind kind =
+          llvm::StringSwitch<Token::Kind>(word)
+              .Case("bool", Token::kw_bool)
+              .Case("char", Token::kw_char)
+              .Case("char16_t", Token::kw_char16_t)
+              .Case("char32_t", Token::kw_char32_t)
+              .Case("const", Token::kw_const)
+              .Case("double", Token::kw_double)
+              .Case("dynamic_cast", Token::kw_dynamic_cast)
+              .Case("false", Token::kw_false)
+              .Case("float", Token::kw_float)
+              .Case("int", Token::kw_int)
+              .Case("long", Token::kw_long)
+              .Case("namespace", Token::kw_namespace)
+              .Case("nullptr", Token::kw_nullptr)
+              .Case("reinterpret_cast", Token::kw_reinterpret_cast)
+              .Case("short", Token::kw_short)
+              .Case("signed", Token::kw_signed)
+              .Case("sizeof", Token::kw_sizeof)
+              .Case("static_cast", Token::kw_static_cast)
+              .Case("true", Token::kw_true)
+              .Case("unsigned", Token::kw_unsigned)
+              .Case("void", Token::kw_void)
+              .Case("volatile", Token::kw_volatile)
+              .Case("wchar_t", Token::kw_wchar_t)
+              .Default(Token::identifier);
       return Token(kind, word.str(), (uint32_t)position);
     }
   }

--- a/lldb/source/ValueObject/DILLiteralParsers.cpp
+++ b/lldb/source/ValueObject/DILLiteralParsers.cpp
@@ -85,8 +85,7 @@ static void Diags_Report(uint32_t loc, dil::diag diag_id, std::string diag_msg)
 {
 }
 
-
-static unsigned getCharWidth(Token::Kind kind) {
+static unsigned GetCharWidth(Token::Kind kind) {
   switch (kind) {
   default: llvm_unreachable("Unknown token type!");
   case Token::char_constant:
@@ -103,7 +102,6 @@ static unsigned getCharWidth(Token::Kind kind) {
 NumericLiteralParser::NumericLiteralParser(llvm::StringRef TokSpelling,
                                            unsigned TokLoc,
                                            bool AllowHalfType,
-                                           //bool AllowFixedPoint,
                                            DILLexer &lexer,
                                            bool AllowMicrosoftExt) :
     ThisTokBegin(TokSpelling.begin()), ThisTokEnd(TokSpelling.end()) {
@@ -172,16 +170,12 @@ NumericLiteralParser::NumericLiteralParser(llvm::StringRef TokSpelling,
     switch (*s) {
     case 'R':
     case 'r':
-      //if (!AllowFixedPoint)
-      //  break;
       if (isFract || isAccum) break;
       if (!(saw_period || saw_exponent)) break;
       isFract = true;
       continue;
     case 'K':
     case 'k':
-      //if (!AllowFixedPoint)
-      //  break;
       if (isFract || isAccum) break;
       if (!(saw_period || saw_exponent)) break;
       isAccum = true;
@@ -189,7 +183,7 @@ NumericLiteralParser::NumericLiteralParser(llvm::StringRef TokSpelling,
     case 'h':      // FP Suffix for "half".
     case 'H':
       // OpenCL Extension v1.2 s9.5 - h or H suffix for half type.
-      if (!(AllowHalfType))// || AllowFixedPoint))
+      if (!(AllowHalfType))
         break;
       if (isIntegerLiteral()) break;  // Error for integer constant.
       if (HasSize)
@@ -203,7 +197,6 @@ NumericLiteralParser::NumericLiteralParser(llvm::StringRef TokSpelling,
       if (HasSize)
         break;
       HasSize = true;
-
 
       isFloat = true;
       continue;  // Success.
@@ -812,7 +805,6 @@ static bool ProcessUCNEscape(const char *ThisTokBegin, const char *&ThisTokBuf,
                              bool in_char_string_literal = false) {
 
   bool HasError;
-  //const char *UcnBegin = ThisTokBuf;
   bool IsDelimitedEscapeSequence = false;
   bool IsNamedEscapeSequence = false;
   if (ThisTokBuf[1] == 'N') {
@@ -1225,7 +1217,7 @@ CharLiteralParser::CharLiteralParser(const char *begin, const char *end,
       ++buffer_begin;
       continue;
     }
-    unsigned CharWidth = getCharWidth(Kind);
+    unsigned CharWidth = GetCharWidth(Kind);
     uint64_t result =
         ProcessCharEscape(TokBegin, begin, end, HadError, Loc,CharWidth,
                           StringLiteralEvalMethod::Evaluated);
@@ -1287,7 +1279,6 @@ StringLiteralParser::StringLiteralParser(llvm::ArrayRef<Token> StringToks,
                                          DILLexer &lexer,
                                          StringLiteralEvalMethod EvalMethod) :
     MaxTokenLength(0), SizeBound(0), CharByteWidth(0),
-    //Kind(Token::unknown),
     ResultPtr(ResultBuf.data()),
     EvalMethod(EvalMethod), m_lexer(lexer), hadError(false) {
   init(StringToks, lexer);
@@ -1353,7 +1344,7 @@ void StringLiteralParser::init(llvm::ArrayRef<Token> StringToks,
   // TODO: K&R warning: "traditional C rejects string constant concatenation"
 
   // Get the width in bytes of char/wchar_t/char16_t/char32_t
-  CharByteWidth = getCharWidth(Kind);
+  CharByteWidth = GetCharWidth(Kind);
   assert((CharByteWidth & 7) == 0 && "Assumes character size is byte multiple");
   CharByteWidth /= 8;
 

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -12,10 +12,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/ValueObject/DILParser.h"
-
-#include <stdlib.h>
-
+#include "lldb/Target/ExecutionContextScope.h"
+#include "lldb/ValueObject/DILAST.h"
+#include "lldb/ValueObject/DILEval.h"
+#include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/TargetParser/Host.h"
 #include <cstdint>
+#include <cstdlib>
+#include <limits.h>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -23,18 +31,6 @@
 #include <tuple>
 #include <type_traits>
 #include <vector>
-
-#include <limits.h>
-
-#include "lldb/lldb-enumerations.h"
-#include "lldb/Target/ExecutionContextScope.h"
-#include "lldb/ValueObject/DILAST.h"
-#include "lldb/ValueObject/DILEval.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/iterator_range.h"
-#include "llvm/Support/FormatAdapters.h"
-#include "llvm/Support/FormatVariadic.h"
-#include "llvm/TargetParser/Host.h"
 
 namespace {
 
@@ -55,29 +51,6 @@ constexpr unsigned type_width() {
 }  // namespace
 
 namespace lldb_private::dil {
-
-inline void TokenKindsJoinImpl(std::ostringstream& os,
-                               Token::Kind k) {
-  os << "'" << Token::GetTokenName(k).str() << "'";
-}
-
-template <typename... Ts>
-inline void TokenKindsJoinImpl(std::ostringstream& os, Token::Kind k,
-                               Ts... ks) {
-  TokenKindsJoinImpl(os, k);
-  os << ", ";
-  TokenKindsJoinImpl(os, ks...);
-}
-
-template <typename... Ts>
-inline std::string TokenKindsJoin(Token::Kind k, Ts... ks) {
-  std::ostringstream os;
-  TokenKindsJoinImpl(os, k, ks...);
-
-  return os.str();
-}
-
-//static std::unordered_map<std::string, CompilerType> context_args;
 
 /// Quick lookup to check if a type name already exists in a
 /// name-to-CompilerType map the DIL parser keeps of previously found
@@ -193,47 +166,13 @@ static bool GetPathToBaseType(CompilerType type, CompilerType target_base,
   return false;
 }
 
-static const char* ToString(TypeDeclaration::TypeSpecifier type_spec) {
-  using TypeSpecifier = TypeDeclaration::TypeSpecifier;
-  switch (type_spec) {
-    case TypeSpecifier::kVoid:       return "void";
-    case TypeSpecifier::kBool:       return "bool";
-    case TypeSpecifier::kChar:       return "char";
-    case TypeSpecifier::kShort:      return "short";
-    case TypeSpecifier::kInt:        return "int";
-    case TypeSpecifier::kLong:       return "long";
-    case TypeSpecifier::kLongLong:   return "long long";
-    case TypeSpecifier::kFloat:      return "float";
-    case TypeSpecifier::kDouble:     return "double";
-    case TypeSpecifier::kLongDouble: return "long double";
-    case TypeSpecifier::kWChar:      return "wchar_t";
-    case TypeSpecifier::kChar16:     return "char16_t";
-    case TypeSpecifier::kChar32:     return "char32_t";
-    default:
-      assert(false && "invalid type specifier");
-      return nullptr;
-  }
-}
-
-static const char* ToString(TypeDeclaration::SignSpecifier sign_spec) {
-  using SignSpecifier = TypeDeclaration::SignSpecifier;
-  switch (sign_spec) {
-    case SignSpecifier::kSigned:   return "signed";
-    case SignSpecifier::kUnsigned: return "unsigned";
-    default:
-      assert(false && "invalid sign specifier");
-      return nullptr;
-  }
-}
-
 static bool TokenEndsTemplateArgumentList(const Token& token) {
   // Note: in C++11 ">>" can be treated as "> >" and thus be a valid token
   // for the template argument list.
-  return token.IsOneOf(Token::comma, Token::greater,
-                       Token::greatergreater);
+  return token.IsOneOf({Token::comma, Token::greater, Token::greatergreater});
 }
 
-static DILASTNodeUP InsertArrayToPointerConversion(DILASTNodeUP expr) {
+static ASTNodeUP InsertArrayToPointerConversion(ASTNodeUP expr) {
   assert(expr->GetDereferencedResultType().IsArrayType() &&
          "an argument to array-to-pointer conversion must be an array");
 
@@ -319,8 +258,9 @@ static CompilerType DoIntegralPromotion(
       : int_type;
 }
 
-static DILASTNodeUP UsualUnaryConversions(
-    std::shared_ptr<ExecutionContextScope>  ctx, DILASTNodeUP expr) {
+static ASTNodeUP
+UsualUnaryConversions(std::shared_ptr<ExecutionContextScope> ctx,
+                      ASTNodeUP expr) {
   // Perform usual conversions for unary operators. At the moment this includes
   // array-to-pointer and the integral promotion for eligible types.
   auto result_type = expr->GetDereferencedResultType();
@@ -429,10 +369,10 @@ static lldb::BasicType BasicTypeToUnsigned(lldb::BasicType basic_type) {
   }
 }
 
-static void PerformIntegerConversions(std::shared_ptr<ExecutionContextScope> ctx,
-                                      DILASTNodeUP& l,
-                                      DILASTNodeUP& r, bool convert_lhs,
-                                      bool convert_rhs) {
+static void
+PerformIntegerConversions(std::shared_ptr<ExecutionContextScope> ctx,
+                          ASTNodeUP &l, ASTNodeUP &r, bool convert_lhs,
+                          bool convert_rhs) {
   // Assert that rank(l) < rank(r).
   auto l_type = l->GetDereferencedResultType();
   auto r_type = r->GetDereferencedResultType();
@@ -470,11 +410,10 @@ static void PerformIntegerConversions(std::shared_ptr<ExecutionContextScope> ctx
   }
 }
 
-static CompilerType UsualArithmeticConversions(
-    std::shared_ptr<ExecutionContextScope> ctx,
-    DILASTNodeUP& lhs,
-    DILASTNodeUP& rhs,
-    bool is_comp_assign = false) {
+static CompilerType
+UsualArithmeticConversions(std::shared_ptr<ExecutionContextScope> ctx,
+                           ASTNodeUP &lhs, ASTNodeUP &rhs,
+                           bool is_comp_assign = false) {
   // Apply unary conversions (e.g. intergal promotion) for both operands.
   // In case of a composite assignment operator LHS shouldn't get promoted.
   if (!is_comp_assign) {
@@ -671,50 +610,182 @@ lldb::BasicType PickCharType(const dil::StringLiteralParser& literal) {
   return lldb::eBasicTypeChar;
 }
 
-std::string FormatDiagnostics(llvm::StringRef text, const std::string& message,
+std::optional<MemberInfo>
+GetFieldWithNameIndexPath(lldb::ValueObjectSP lhs_val_sp, CompilerType type,
+                          const std::string &name, std::vector<uint32_t> *idx,
+                          CompilerType empty_type, bool use_synthetic,
+                          bool is_dynamic, bool is_arrow) {
+  bool is_synthetic = false;
+  // Go through the fields first.
+  uint32_t num_fields = type.GetNumFields();
+  lldb::ValueObjectSP empty_valobj_sp;
+  for (uint32_t i = 0; i < num_fields; ++i) {
+    uint64_t bit_offset = 0;
+    uint32_t bitfield_bit_size = 0;
+    bool is_bitfield = false;
+    std::string name_sstr;
+    CompilerType field_type(type.GetFieldAtIndex(
+        i, name_sstr, &bit_offset, &bitfield_bit_size, &is_bitfield));
+    auto field_name =
+        name_sstr.length() == 0 ? std::optional<std::string>() : name_sstr;
+    if (field_type.IsValid()) {
+      std::optional<uint32_t> size_in_bits;
+      if (is_bitfield)
+        size_in_bits = bitfield_bit_size;
+      struct MemberInfo field = {field_name,   field_type, size_in_bits,
+                                 is_synthetic, is_dynamic, empty_valobj_sp};
+
+      // Name can be null if this is a padding field.
+      if (field.name == name) {
+        if (lhs_val_sp) {
+          lldb::ValueObjectSP child_valobj_sp =
+              lhs_val_sp->GetChildMemberWithName(name);
+          if (child_valobj_sp &&
+              child_valobj_sp->GetName() == ConstString(name))
+            field.val_obj_sp = child_valobj_sp;
+        }
+
+        if (idx) {
+          assert(idx->empty());
+          // Direct base classes are located before fields, so field members
+          // needs to be offset by the number of base classes.
+          idx->push_back(i + type.GetNumberOfNonEmptyBaseClasses());
+        }
+        return field;
+      } else if (field.type.IsAnonymousType()) {
+        // Every member of an anonymous struct is considered to be a member of
+        // the enclosing struct or union. This applies recursively if the
+        // enclosing struct or union is also anonymous.
+
+        assert(!field.name && "Field should be unnamed.");
+
+        std::optional<MemberInfo> field_in_anon_type =
+            GetFieldWithNameIndexPath(lhs_val_sp, field.type, name, idx,
+                                      empty_type, use_synthetic, is_dynamic,
+                                      is_arrow);
+        if (field_in_anon_type) {
+          if (idx) {
+            idx->push_back(i + type.GetNumberOfNonEmptyBaseClasses());
+          }
+          return field_in_anon_type.value();
+        }
+      }
+    }
+  }
+
+  // LLDB can't access inherited fields of anonymous struct members.
+  if (type.IsAnonymousType()) {
+    return {};
+  }
+
+  // Go through the base classes and look for the field there.
+  uint32_t num_non_empty_bases = 0;
+  uint32_t num_direct_bases = type.GetNumDirectBaseClasses();
+  for (uint32_t i = 0; i < num_direct_bases; ++i) {
+    uint32_t bit_offset;
+    auto base = type.GetDirectBaseClassAtIndex(i, &bit_offset);
+    auto field =
+        GetFieldWithNameIndexPath(lhs_val_sp, base, name, idx, empty_type,
+                                  use_synthetic, is_dynamic, is_arrow);
+    if (field) {
+      if (idx) {
+        idx->push_back(num_non_empty_bases);
+      }
+      return field.value();
+    }
+    if (base.GetNumFields() > 0) {
+      num_non_empty_bases += 1;
+    }
+  }
+
+  // Check for synthetic member
+  if (lhs_val_sp && use_synthetic) {
+    lldb::ValueObjectSP child_valobj_sp = lhs_val_sp->GetSyntheticValue();
+    if (child_valobj_sp) {
+      is_synthetic = true;
+      uint32_t child_idx = child_valobj_sp->GetIndexOfChildWithName(name);
+      child_valobj_sp = child_valobj_sp->GetChildMemberWithName(name);
+      if (child_valobj_sp) {
+        CompilerType field_type = child_valobj_sp->GetCompilerType();
+        if (field_type.IsValid()) {
+          struct MemberInfo field = {name,         field_type, {},
+                                     is_synthetic, is_dynamic, child_valobj_sp};
+          if (idx) {
+            assert(idx->empty());
+            idx->push_back(child_idx);
+          }
+          return field;
+        }
+      }
+    }
+  }
+
+  if (lhs_val_sp) {
+    lldb::ValueObjectSP dynamic_val_sp =
+        lhs_val_sp->GetDynamicValue(lldb::eDynamicDontRunTarget);
+    if (dynamic_val_sp) {
+      CompilerType lhs_type = dynamic_val_sp->GetCompilerType();
+      if (lhs_type.IsPointerType())
+        lhs_type = lhs_type.GetPointeeType();
+      is_dynamic = true;
+      return GetFieldWithNameIndexPath(dynamic_val_sp, lhs_type, name, idx,
+                                       empty_type, use_synthetic, is_dynamic,
+                                       is_arrow);
+    }
+  }
+
+  return {};
+}
+
+std::tuple<std::optional<MemberInfo>, std::vector<uint32_t>>
+GetMemberInfo(lldb::ValueObjectSP lhs_val_sp, CompilerType type,
+              const std::string &name, bool use_synthetic, bool is_arrow) {
+  std::vector<uint32_t> idx;
+  CompilerType empty_type;
+  bool is_dynamic = false;
+  std::optional<MemberInfo> member =
+      GetFieldWithNameIndexPath(lhs_val_sp, type, name, &idx, empty_type,
+                                use_synthetic, is_dynamic, is_arrow);
+  std::reverse(idx.begin(), idx.end());
+  return {member, std::move(idx)};
+}
+
+std::string FormatDiagnostics(llvm::StringRef text, const std::string &message,
                               uint32_t loc) {
-  // Get the location of the current token.
-  size_t loc_offset = (size_t) loc;
-
-  // Look for the start of the line.
-  size_t line_start = text.rfind('\n', loc_offset);
-  line_start = line_start == llvm::StringRef::npos ? 0 : line_start + 1;
-
-  // Look for the end of the line.
-  size_t line_end = text.find('\n', loc_offset);
-  line_end = line_end == llvm::StringRef::npos ? text.size() : line_end;
-
-  // Get a view of the current line in the source code and the position of the
-  // diagnostics pointer.
-  llvm::StringRef line = text.slice(line_start, line_end);
+  // Get the position, in the current line of text, of the diagnostics pointer.
+  // ('loc' is the location of the start of the current token/error within the
+  // overall text line).
   int32_t arrow = loc + 1; // Column offset starts at 1, not 0.
 
-  // Calculate the padding in case we point outside of the expression (this can
-  // happen if the parser expected something, but got EOF).˚
-  size_t expr_rpad = std::max(0, arrow - static_cast<int32_t>(line.size()));
-  size_t arrow_rpad = std::max(0, static_cast<int32_t>(line.size()) - arrow);
+  return llvm::formatv("<expr:1:{0}>: {1}\n{2}\n{3}", loc + 1, message,
+                       llvm::fmt_pad(text, 0, 0),
+                       llvm::fmt_pad("^", arrow - 1, 0));
+}
 
-  return llvm::formatv("<expr:1:{0}>: {1}\n{2}\n{3}", loc + 1,
-                       message, llvm::fmt_pad(line, 0, expr_rpad),
-                       llvm::fmt_pad("^", arrow - 1, arrow_rpad));
+llvm::Expected<ASTNodeUP>
+DILParser::Parse(llvm::StringRef dil_input_expr, DILLexer lexer,
+                 std::shared_ptr<StackFrame> frame_sp,
+                 lldb::DynamicValueType use_dynamic, bool use_synthetic,
+                 bool fragile_ivar, bool check_ptr_vs_member) {
+  Status error;
+  DILParser parser(dil_input_expr, lexer, frame_sp, use_dynamic, use_synthetic,
+                   fragile_ivar, check_ptr_vs_member, error);
+  return parser.Run();
 }
 
 DILParser::DILParser(llvm::StringRef dil_input_expr, DILLexer lexer,
-                     std::shared_ptr<ExecutionContextScope> exe_ctx_scope,
+                     std::shared_ptr<StackFrame> frame_sp,
                      lldb::DynamicValueType use_dynamic, bool use_synthetic,
-                     bool fragile_ivar, bool check_ptr_vs_member)
-    : m_ctx_scope(exe_ctx_scope), m_input_expr(dil_input_expr),
-    m_dil_lexer(lexer), m_dil_token(lexer.GetCurrentToken()),
-    m_use_dynamic(use_dynamic),
-    m_use_synthetic(use_synthetic), m_fragile_ivar(fragile_ivar),
-    m_check_ptr_vs_member(check_ptr_vs_member)
-{
-}
+                     bool fragile_ivar, bool check_ptr_vs_member, Status &error)
+    : m_ctx_scope(frame_sp), m_input_expr(dil_input_expr), m_dil_lexer(lexer),
+      m_error(error), m_use_dynamic(use_dynamic),
+      m_use_synthetic(use_synthetic), m_fragile_ivar(fragile_ivar),
+      m_check_ptr_vs_member(check_ptr_vs_member) {}
 
-DILASTNodeUP DILParser::Run(Status& error) {
-  DILASTNodeUP expr;
+llvm::Expected<ASTNodeUP> DILParser::Run() {
+  ASTNodeUP expr;
 
-  if (m_dil_lexer.IsStringLiteral(m_dil_token.GetKind()) &&
+  if (m_dil_lexer.IsStringLiteral(CurToken().GetKind()) &&
       m_dil_lexer.LookAhead(1).Is(Token::eof)) {
     // A special case to handle a single string-literal token.
     expr = ParseStringLiteral();
@@ -722,19 +793,12 @@ DILASTNodeUP DILParser::Run(Status& error) {
     expr = ParseExpression();
   }
 
-
   Expect(Token::eof);
 
-  error = std::move(m_error);
-  m_error.Clear();
+  // Check for any parsing errors.
+  if (m_error.Fail())
+    return m_error.ToError();
 
-  // Explicitly return ErrorNode if there was an error during the parsing.
-  // Some routines raise an error, but don't change the return value (e.g.
-  // Expect).
-  if (error.Fail()) {
-    CompilerType bad_type;
-    return std::make_unique<ErrorNode>(bad_type);
-  }
   return expr;
 }
 
@@ -773,20 +837,19 @@ CompilerType DILParser::ResolveTypeDeclarators(
 }
 
 bool DILParser::IsSimpleTypeSpecifierKeyword(Token token) const {
-  return token.IsOneOf(
-      Token::kw_char, Token::kw_char16_t, Token::kw_char32_t,
-      Token::kw_wchar_t, Token::kw_bool, Token::kw_short,
-      Token::kw_int, Token::kw_long, Token::kw_signed,
-      Token::kw_unsigned, Token::kw_float, Token::kw_double,
-      Token::kw_void);
+  return token.IsOneOf({Token::kw_char, Token::kw_char16_t, Token::kw_char32_t,
+                        Token::kw_wchar_t, Token::kw_bool, Token::kw_short,
+                        Token::kw_int, Token::kw_long, Token::kw_signed,
+                        Token::kw_unsigned, Token::kw_float, Token::kw_double,
+                        Token::kw_void});
 }
 
 bool DILParser::IsCvQualifier(Token token) const {
-  return token.IsOneOf(Token::kw_const, Token::kw_volatile);
+  return token.IsOneOf({Token::kw_const, Token::kw_volatile});
 }
 
 bool DILParser::IsPtrOperator(Token token) const {
-  return token.IsOneOf(Token::star, Token::amp);
+  return token.IsOneOf({Token::star, Token::amp});
 }
 
 bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
@@ -794,8 +857,8 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
   using SignSpecifier = TypeDeclaration::SignSpecifier;
 
   TypeSpecifier type_spec = type_decl->m_type_specifier;
-  uint32_t loc = m_dil_token.GetLocation();
-  Token::Kind kind = m_dil_token.GetKind();
+  uint32_t loc = CurToken().GetLocation();
+  Token::Kind kind = CurToken().GetKind();
 
   switch (kind) {
     case Token::kw_int: {
@@ -820,7 +883,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       BailOut(ErrorCode::kInvalidOperandType,
               llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
-                  ToString(type_spec)),
+                  type_spec),
               loc);
       return false;
     }
@@ -842,7 +905,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       BailOut(ErrorCode::kInvalidOperandType,
               llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
-                  ToString(type_spec)),
+                  type_spec),
               loc);
       return false;
     }
@@ -857,7 +920,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       BailOut(ErrorCode::kInvalidOperandType,
               llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
-                  ToString(type_spec)),
+                  type_spec),
               loc);
       return false;
     }
@@ -872,7 +935,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       BailOut(ErrorCode::kInvalidOperandType,
               llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
-                  ToString(type_spec)),
+                  type_spec),
               loc);
       return false;
     }
@@ -895,7 +958,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       BailOut(ErrorCode::kInvalidOperandType,
               llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
-                  ToString(type_spec)),
+                  type_spec),
               loc);
       return false;
     }
@@ -911,7 +974,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       if (type_decl->m_sign_specifier != SignSpecifier::kUnknown) {
         BailOut(ErrorCode::kInvalidOperandType,
                 llvm::formatv("'{0}' cannot be signed or unsigned",
-                              ToString(ToTypeSpecifier(kind))),
+                              ToTypeSpecifier(kind)),
                 loc);
         return false;
       }
@@ -919,7 +982,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
         BailOut(ErrorCode::kInvalidOperandType,
                 llvm::formatv(
                     "cannot combine with previous '{0}' declaration specifier",
-                    ToString(type_spec)),
+                    type_spec),
                 loc);
       }
       type_decl->m_type_specifier = ToTypeSpecifier(kind);
@@ -934,7 +997,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
         BailOut(ErrorCode::kInvalidOperandType,
                 llvm::formatv(
                     "cannot combine with previous '{0}' declaration specifier",
-                    ToString(type_decl->m_sign_specifier)),
+                    type_decl->m_sign_specifier),
                 loc);
         return false;
       }
@@ -947,8 +1010,7 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
           type_spec == TypeSpecifier::kChar16 ||
           type_spec == TypeSpecifier::kChar32) {
         BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv("'{0}' cannot be signed or unsigned",
-                              ToString(type_spec)),
+                llvm::formatv("'{0}' cannot be signed or unsigned", type_spec),
                 loc);
         return false;
       }
@@ -965,24 +1027,24 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
   }
 }
 
-DILASTNodeUP DILParser::ParseStringLiteral() {
-  ExpectOneOf(Token::string_literal, Token::wide_string_literal,
-              Token::utf8_string_literal);
-  uint32_t loc = m_dil_token.GetLocation();
+ASTNodeUP DILParser::ParseStringLiteral() {
+  ExpectOneOf(std::vector<Token::Kind>{Token::string_literal,
+                                       Token::wide_string_literal,
+                                       Token::utf8_string_literal});
+  uint32_t loc = CurToken().GetLocation();
 
   // TODO: Support parsing of joined string-literals (e.g. "abc" "def").
   // Currently, only a single token can be parsed into a string.
-  dil::StringLiteralParser string_literal(
-      llvm::ArrayRef<Token>(m_dil_token), m_dil_lexer);
+  dil::StringLiteralParser string_literal(llvm::ArrayRef<Token>(CurToken()),
+                                          m_dil_lexer);
 
   if (string_literal.hadError) {
     // TODO: Use ErrorCode::kInvalidStringLiteral in the future.
     BailOut(ErrorCode::kInvalidNumericLiteral,
             llvm::formatv("Failed to parse token as string-literal: {0}",
-                          TokenDescription(m_dil_token)),
+                          CurToken()),
             loc);
-    CompilerType bad_type;
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   auto char_type = GetBasicType(m_ctx_scope, PickCharType(string_literal));
@@ -999,7 +1061,7 @@ DILASTNodeUP DILParser::ParseStringLiteral() {
 
   assert(data.size() == array_type.GetByteSize(nullptr) &&
          "invalid string literal: unexpected data size");
-  ConsumeToken();
+  m_dil_lexer.Advance();
   return std::make_unique<StringLiteralNode>(loc, array_type, std::move(data));
 }
 
@@ -1008,7 +1070,7 @@ DILASTNodeUP DILParser::ParseStringLiteral() {
 //  expression:
 //    assignment_expression
 //
-DILASTNodeUP DILParser::ParseExpression() { return ParseAssignmentExpression(); }
+ASTNodeUP DILParser::ParseExpression() { return ParseAssignmentExpression(); }
 
 // Parse an assignment_expression.
 //
@@ -1033,31 +1095,30 @@ DILASTNodeUP DILParser::ParseExpression() { return ParseAssignmentExpression(); 
 //    logical_or_expression
 //    logical_or_expression "?" expression ":" assignment_expression
 //
-DILASTNodeUP DILParser::ParseAssignmentExpression() {
+ASTNodeUP DILParser::ParseAssignmentExpression() {
   auto lhs = ParseLogicalOrExpression();
 
   // Check if it's an assignment expression.
-  if (m_dil_token.IsOneOf(Token::equal, Token::starequal,
-                     Token::slashequal, Token::percentequal,
-                     Token::plusequal, Token::minusequal,
-                     Token::greatergreaterequal, Token::lesslessequal,
-                     Token::ampequal, Token::caretequal,
-                     Token::pipeequal)) {
+  if (CurToken().IsOneOf({Token::equal, Token::starequal, Token::slashequal,
+                          Token::percentequal, Token::plusequal,
+                          Token::minusequal, Token::greatergreaterequal,
+                          Token::lesslessequal, Token::ampequal,
+                          Token::caretequal, Token::pipeequal})) {
     // That's an assignment!
-    Token token = m_dil_token;
-    ConsumeToken();
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseAssignmentExpression();
     lhs = BuildBinaryOp(dil_token_kind_to_binary_op_kind(token.GetKind()),
                         std::move(lhs), std::move(rhs), token.GetLocation());
   }
 
   // Check if it's a conditional expression.
-  if (m_dil_token.Is(Token::question)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  if (CurToken().Is(Token::question)) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto true_val = ParseExpression();
     Expect(Token::colon);
-    ConsumeToken();
+    m_dil_lexer.Advance();
     auto false_val = ParseAssignmentExpression();
     lhs = BuildTernaryOp(std::move(lhs), std::move(true_val),
                          std::move(false_val), token.GetLocation());
@@ -1071,12 +1132,12 @@ DILASTNodeUP DILParser::ParseAssignmentExpression() {
 //  logical_or_expression:
 //    logical_and_expression {"||" logical_and_expression}
 //
-DILASTNodeUP DILParser::ParseLogicalOrExpression() {
+ASTNodeUP DILParser::ParseLogicalOrExpression() {
   auto lhs = ParseLogicalAndExpression();
 
-  while (m_dil_token.Is(Token::pipepipe)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().Is(Token::pipepipe)) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseLogicalAndExpression();
     lhs = BuildBinaryOp(BinaryOpKind::LOr, std::move(lhs), std::move(rhs),
                         token.GetLocation());
@@ -1090,12 +1151,12 @@ DILASTNodeUP DILParser::ParseLogicalOrExpression() {
 //  logical_and_expression:
 //    inclusive_or_expression {"&&" inclusive_or_expression}
 //
-DILASTNodeUP DILParser::ParseLogicalAndExpression() {
+ASTNodeUP DILParser::ParseLogicalAndExpression() {
   auto lhs = ParseInclusiveOrExpression();
 
-  while (m_dil_token.Is(Token::ampamp)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().Is(Token::ampamp)) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseInclusiveOrExpression();
     lhs = BuildBinaryOp(BinaryOpKind::LAnd, std::move(lhs), std::move(rhs),
                         token.GetLocation());
@@ -1109,12 +1170,12 @@ DILASTNodeUP DILParser::ParseLogicalAndExpression() {
 //  inclusive_or_expression:
 //    exclusive_or_expression {"|" exclusive_or_expression}
 //
-DILASTNodeUP DILParser::ParseInclusiveOrExpression() {
+ASTNodeUP DILParser::ParseInclusiveOrExpression() {
   auto lhs = ParseExclusiveOrExpression();
 
-  while (m_dil_token.Is(Token::pipe)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().Is(Token::pipe)) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseExclusiveOrExpression();
     lhs = BuildBinaryOp(BinaryOpKind::Or, std::move(lhs), std::move(rhs),
                         token.GetLocation());
@@ -1128,12 +1189,12 @@ DILASTNodeUP DILParser::ParseInclusiveOrExpression() {
 //  exclusive_or_expression:
 //    and_expression {"^" and_expression}
 //
-DILASTNodeUP DILParser::ParseExclusiveOrExpression() {
+ASTNodeUP DILParser::ParseExclusiveOrExpression() {
   auto lhs = ParseAndExpression();
 
-  while (m_dil_token.Is(Token::caret)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().Is(Token::caret)) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseAndExpression();
     lhs = BuildBinaryOp(BinaryOpKind::Xor, std::move(lhs), std::move(rhs),
                         token.GetLocation());
@@ -1147,12 +1208,12 @@ DILASTNodeUP DILParser::ParseExclusiveOrExpression() {
 //  and_expression:
 //    equality_expression {"&" equality_expression}
 //
-DILASTNodeUP DILParser::ParseAndExpression() {
+ASTNodeUP DILParser::ParseAndExpression() {
   auto lhs = ParseEqualityExpression();
 
-  while (m_dil_token.Is(Token::amp)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().Is(Token::amp)) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseEqualityExpression();
     lhs = BuildBinaryOp(BinaryOpKind::And, std::move(lhs), std::move(rhs),
                         token.GetLocation());
@@ -1167,12 +1228,12 @@ DILASTNodeUP DILParser::ParseAndExpression() {
 //    relational_expression {"==" relational_expression}
 //    relational_expression {"!=" relational_expression}
 //
-DILASTNodeUP DILParser::ParseEqualityExpression() {
+ASTNodeUP DILParser::ParseEqualityExpression() {
   auto lhs = ParseRelationalExpression();
 
-  while (m_dil_token.IsOneOf(Token::equalequal, Token::exclaimequal)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().IsOneOf({Token::equalequal, Token::exclaimequal})) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseRelationalExpression();
     lhs = BuildBinaryOp(dil_token_kind_to_binary_op_kind(token.GetKind()),
                         std::move(lhs), std::move(rhs), token.GetLocation());
@@ -1189,13 +1250,13 @@ DILASTNodeUP DILParser::ParseEqualityExpression() {
 //    shift_expression {"<=" shift_expression}
 //    shift_expression {">=" shift_expression}
 //
-DILASTNodeUP DILParser::ParseRelationalExpression() {
+ASTNodeUP DILParser::ParseRelationalExpression() {
   auto lhs = ParseShiftExpression();
 
-  while (m_dil_token.IsOneOf(Token::less, Token::greater,
-                        Token::lessequal, Token::greaterequal)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().IsOneOf(
+      {Token::less, Token::greater, Token::lessequal, Token::greaterequal})) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseShiftExpression();
     lhs = BuildBinaryOp(dil_token_kind_to_binary_op_kind(token.GetKind()),
                         std::move(lhs), std::move(rhs), token.GetLocation());
@@ -1210,12 +1271,12 @@ DILASTNodeUP DILParser::ParseRelationalExpression() {
 //    additive_expression {"<<" additive_expression}
 //    additive_expression {">>" additive_expression}
 //
-DILASTNodeUP DILParser::ParseShiftExpression() {
+ASTNodeUP DILParser::ParseShiftExpression() {
   auto lhs = ParseAdditiveExpression();
 
-  while (m_dil_token.IsOneOf(Token::lessless, Token::greatergreater)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().IsOneOf({Token::lessless, Token::greatergreater})) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseAdditiveExpression();
     lhs = BuildBinaryOp(dil_token_kind_to_binary_op_kind(token.GetKind()),
                         std::move(lhs), std::move(rhs), token.GetLocation());
@@ -1230,12 +1291,12 @@ DILASTNodeUP DILParser::ParseShiftExpression() {
 //    multiplicative_expression {"+" multiplicative_expression}
 //    multiplicative_expression {"-" multiplicative_expression}
 //
-DILASTNodeUP DILParser::ParseAdditiveExpression() {
+ASTNodeUP DILParser::ParseAdditiveExpression() {
   auto lhs = ParseMultiplicativeExpression();
 
-  while (m_dil_token.IsOneOf(Token::plus, Token::minus)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().IsOneOf({Token::plus, Token::minus})) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseMultiplicativeExpression();
     lhs = BuildBinaryOp(dil_token_kind_to_binary_op_kind(token.GetKind()),
                         std::move(lhs), std::move(rhs), token.GetLocation());
@@ -1251,13 +1312,12 @@ DILASTNodeUP DILParser::ParseAdditiveExpression() {
 //    cast_expression {"/" cast_expression}
 //    cast_expression {"%" cast_expression}
 //
-DILASTNodeUP DILParser::ParseMultiplicativeExpression() {
+ASTNodeUP DILParser::ParseMultiplicativeExpression() {
   auto lhs = ParseCastExpression();
 
-  while (m_dil_token.IsOneOf(Token::star, Token::slash,
-                        Token::percent)) {
-    Token token = m_dil_token;
-    ConsumeToken();
+  while (CurToken().IsOneOf({Token::star, Token::slash, Token::percent})) {
+    Token token = CurToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseCastExpression();
     lhs = BuildBinaryOp(dil_token_kind_to_binary_op_kind(token.GetKind()),
                         std::move(lhs), std::move(rhs), token.GetLocation());
@@ -1266,18 +1326,16 @@ DILASTNodeUP DILParser::ParseMultiplicativeExpression() {
   return lhs;
 }
 
-
-
 // Parse a cast_expression.
 //
 //  cast_expression:
 //    unary_expression
 //    "(" type_id ")" cast_expression
 //
-DILASTNodeUP DILParser::ParseCastExpression() {
+ASTNodeUP DILParser::ParseCastExpression() {
   // This can be a C-style cast, try parsing the contents as a type declaration.
-  if (m_dil_token.Is(Token::l_paren)) {
-    Token token = m_dil_token;
+  if (CurToken().Is(Token::l_paren)) {
+    Token token = CurToken();
 
     // Enable lexer backtracking, so that we can rollback in case it's not
     // actually a type declaration.
@@ -1286,7 +1344,7 @@ DILASTNodeUP DILParser::ParseCastExpression() {
     uint32_t save_token_idx = m_dil_lexer.GetCurrentTokenIdx();
 
     // Consume the token only after enabling the backtracking.
-    ConsumeToken();
+    m_dil_lexer.Advance();
 
     // Try parsing the type declaration. If the returned value is not valid,
     // then we should rollback and try parsing the expression.
@@ -1295,13 +1353,11 @@ DILASTNodeUP DILParser::ParseCastExpression() {
       // Successfully parsed the type declaration. Commit the backtracked
       // tokens and parse the cast_expression.
 
-      if (!type_id.value().IsValid()) {
-        CompilerType bad_type;
-        return std::make_unique<ErrorNode>(bad_type);
-      }
+      if (!type_id.value().IsValid())
+        return std::make_unique<ErrorNode>();
 
       Expect(Token::r_paren);
-      ConsumeToken();
+      m_dil_lexer.Advance();
       auto rhs = ParseCastExpression();
 
       return BuildCStyleCast(type_id.value(), std::move(rhs),
@@ -1310,13 +1366,11 @@ DILASTNodeUP DILParser::ParseCastExpression() {
 
     // Failed to parse the contents of the parentheses as a type declaration.
     // Rollback the lexer and try parsing it as unary_expression.
-
     TentativeParsingRollback(save_token_idx);
   }
 
   return ParseUnaryExpression();
 }
-
 
 // Parse an unary_expression.
 //
@@ -1336,14 +1390,13 @@ DILASTNodeUP DILParser::ParseCastExpression() {
 //    "~"
 //    "!"
 //
-DILASTNodeUP DILParser::ParseUnaryExpression() {
-  if (m_dil_token.IsOneOf(Token::plusplus, Token::minusminus,
-                     Token::star, Token::amp, Token::plus,
-                     Token::minus, Token::exclaim,
-                     Token::tilde)) {
-    Token token = m_dil_token;
+ASTNodeUP DILParser::ParseUnaryExpression() {
+  if (CurToken().IsOneOf({Token::plusplus, Token::minusminus, Token::star,
+                          Token::amp, Token::plus, Token::minus, Token::exclaim,
+                          Token::tilde})) {
+    Token token = CurToken();
     uint32_t loc = token.GetLocation();
-    ConsumeToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseCastExpression();
 
     switch (token.GetKind()) {
@@ -1369,9 +1422,9 @@ DILASTNodeUP DILParser::ParseUnaryExpression() {
     }
   }
 
-  if (m_dil_token.Is(Token::kw_sizeof)) {
-    uint32_t sizeof_loc = m_dil_token.GetLocation();
-    ConsumeToken();
+  if (CurToken().Is(Token::kw_sizeof)) {
+    uint32_t sizeof_loc = CurToken().GetLocation();
+    m_dil_lexer.Advance();
 
     // [expr.sizeof](http://eel.is/c++draft/expr.sizeof#1)
     //
@@ -1383,20 +1436,20 @@ DILASTNodeUP DILParser::ParseUnaryExpression() {
     CompilerType operand;
 
     // `(` can mean either a type_id or a parenthesized expression.
-    if (m_dil_token.Is(Token::l_paren)) {
+    if (CurToken().Is(Token::l_paren)) {
       // Start tentative parsing (save token location/idx, for possible
       // rollback).
       uint32_t save_token_idx = m_dil_lexer.GetCurrentTokenIdx();
 
       Expect(Token::l_paren);
-      ConsumeToken();
+      m_dil_lexer.Advance();
 
       // Parse the type definition and resolve the type.
       auto type_id = ParseTypeId();
       if (type_id) {
         // type_id requires parentheses, so there must be a closing one.
         Expect(Token::r_paren);
-        ConsumeToken();
+        m_dil_lexer.Advance();
 
         operand = type_id.value();
 
@@ -1411,10 +1464,8 @@ DILASTNodeUP DILParser::ParseUnaryExpression() {
       // No opening parenthesis means this must be an unary_expression.
       operand = ParseUnaryExpression()->GetDereferencedResultType();
     }
-    if (!operand.IsValid()) {
-      CompilerType bad_type;
-      return std::make_unique<ErrorNode>(bad_type);
-    }
+    if (!operand.IsValid())
+      return std::make_unique<ErrorNode>();
 
     lldb::BasicType size_type;
     llvm::Triple triple(llvm::Twine(
@@ -1447,43 +1498,43 @@ DILASTNodeUP DILParser::ParseUnaryExpression() {
 //    dynamic_cast "<" type_id ">" "(" expression ")" ;
 //    reinterpret_cast "<" type_id ">" "(" expression ")" ;
 //
-DILASTNodeUP DILParser::ParsePostfixExpression() {
+ASTNodeUP DILParser::ParsePostfixExpression() {
   // Parse the first part of the postfix_expression. This could be either a
   // primary_expression, or a postfix_expression itself.
-  DILASTNodeUP lhs;
+  ASTNodeUP lhs;
   CompilerType bad_type;
 
   // C++-style cast.
-  if (m_dil_token.IsOneOf(Token::kw_static_cast, Token::kw_dynamic_cast,
-                     Token::kw_reinterpret_cast)) {
-    Token::Kind cast_kind = m_dil_token.GetKind();
-    uint32_t cast_loc = m_dil_token.GetLocation();
-    ConsumeToken();
+  if (CurToken().IsOneOf({Token::kw_static_cast, Token::kw_dynamic_cast,
+                          Token::kw_reinterpret_cast})) {
+    Token::Kind cast_kind = CurToken().GetKind();
+    uint32_t cast_loc = CurToken().GetLocation();
+    m_dil_lexer.Advance();
 
     Expect(Token::less);
-    ConsumeToken();
+    m_dil_lexer.Advance();
 
-    uint32_t loc = m_dil_token.GetLocation();
+    uint32_t loc = CurToken().GetLocation();
 
     // Parse the type definition and resolve the type.
     auto type_id = ParseTypeId(/*must_be_type_id*/ true);
     if (!type_id) {
       BailOut(ErrorCode::kInvalidOperandType,
               "type name requires a specifier or qualifier", loc);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
     if (!type_id.value().IsValid()) {
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
 
     Expect(Token::greater);
-    ConsumeToken();
+    m_dil_lexer.Advance();
 
     Expect(Token::l_paren);
-    ConsumeToken();
+    m_dil_lexer.Advance();
     auto rhs = ParseExpression();
     Expect(Token::r_paren);
-    ConsumeToken();
+    m_dil_lexer.Advance();
 
     lhs = BuildCxxCast(cast_kind, type_id.value(), std::move(rhs), cast_loc);
 
@@ -1493,23 +1544,22 @@ DILASTNodeUP DILParser::ParsePostfixExpression() {
   }
   assert(lhs && "LHS of the postfix_expression can't be NULL.");
 
-  while (m_dil_token.IsOneOf(Token::l_square, Token::period,
-                        Token::arrow, Token::plusplus,
-                        Token::minusminus)) {
-    Token token = m_dil_token;
+  while (CurToken().IsOneOf({Token::l_square, Token::period, Token::arrow,
+                             Token::plusplus, Token::minusminus})) {
+    Token token = CurToken();
     switch (token.GetKind()) {
       case Token::period:
       case Token::arrow: {
-        ConsumeToken();
-        Token member_token = m_dil_token;
+        m_dil_lexer.Advance();
+        Token member_token = CurToken();
         auto member_id = ParseIdExpression();
         // Check if this is a function call.
-        if (m_dil_token.Is(Token::l_paren)) {
+        if (CurToken().Is(Token::l_paren)) {
           // TODO: Check if `member_id` is actually a member function of `lhs`.
           // If not, produce a more accurate diagnostic.
           BailOut(ErrorCode::kNotImplemented,
                   "member function calls are not supported",
-                  m_dil_token.GetLocation());
+                  CurToken().GetLocation());
         }
         lhs = BuildMemberOf(std::move(lhs), std::move(member_id),
                             token.GetKind() == Token::arrow,
@@ -1517,20 +1567,20 @@ DILASTNodeUP DILParser::ParsePostfixExpression() {
         break;
       }
       case Token::plusplus: {
-        ConsumeToken();
+        m_dil_lexer.Advance();
         return BuildUnaryOp(UnaryOpKind::PostInc, std::move(lhs),
                             token.GetLocation());
       }
       case Token::minusminus: {
-        ConsumeToken();
+        m_dil_lexer.Advance();
         return BuildUnaryOp(UnaryOpKind::PostDec, std::move(lhs),
                             token.GetLocation());
       }
       case Token::l_square: {
-        ConsumeToken();
+        m_dil_lexer.Advance();
         auto rhs = ParseExpression();
         Expect(Token::r_square);
-        ConsumeToken();
+        m_dil_lexer.Advance();
         lhs = BuildBinarySubscript(std::move(lhs), std::move(rhs),
                                    token.GetLocation());
         break;
@@ -1551,34 +1601,33 @@ DILASTNodeUP DILParser::ParsePostfixExpression() {
 //    boolean_literal
 //    pointer_literal
 //    id_expression
-//    "this"
 //    "(" expression ")"
 //    builtin_func
 //
-DILASTNodeUP DILParser::ParsePrimaryExpression() {
+ASTNodeUP DILParser::ParsePrimaryExpression() {
   CompilerType bad_type;
-  if (m_dil_token.Is(Token::numeric_constant)) {
+  if (CurToken().Is(Token::numeric_constant)) {
     return ParseNumericLiteral();
-  } else if (m_dil_token.IsOneOf(Token::kw_true, Token::kw_false)) {
+  } else if (CurToken().IsOneOf({Token::kw_true, Token::kw_false})) {
     return ParseBooleanLiteral();
-  } else if (m_dil_token.IsOneOf(Token::char_constant,
-                            Token::wide_char_constant,
-                            Token::utf8_char_constant)) {
+  } else if (CurToken().IsOneOf({Token::char_constant,
+                                 Token::wide_char_constant,
+                                 Token::utf8_char_constant})) {
     return ParseCharLiteral();
-  } else if (m_dil_lexer.IsStringLiteral(m_dil_token.GetKind())) {
+  } else if (m_dil_lexer.IsStringLiteral(CurToken().GetKind())) {
     // Note: Only expressions that consist of a single string literal can be
     // handled by DIL.
     BailOut(ErrorCode::kNotImplemented, "string literals are not supported",
-            m_dil_token.GetLocation());
-    return std::make_unique<ErrorNode>(bad_type);
-  } else if (m_dil_token.Is(Token::kw_nullptr)) {
+            CurToken().GetLocation());
+    return std::make_unique<ErrorNode>();
+  } else if (CurToken().Is(Token::kw_nullptr)) {
     return ParsePointerLiteral();
-  } else if (m_dil_token.IsOneOf(Token::coloncolon, Token::identifier)) {
+  } else if (CurToken().IsOneOf({Token::coloncolon, Token::identifier})) {
     // Save the source location for the diagnostics message.
-    uint32_t loc = m_dil_token.GetLocation();
+    uint32_t loc = CurToken().GetLocation();
     auto identifier = ParseIdExpression();
     // Check if this is a function call.
-    if (m_dil_token.Is(Token::l_paren)) {
+    if (CurToken().Is(Token::l_paren)) {
       auto func_def = GetBuiltinFunctionDef(m_ctx_scope, identifier);
       if (!func_def) {
         BailOut(
@@ -1586,39 +1635,29 @@ DILASTNodeUP DILParser::ParsePrimaryExpression() {
             llvm::formatv("function '{0}' is not a supported builtin intrinsic",
                           identifier),
             loc);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
       return ParseBuiltinFunction(loc, std::move(func_def));
     }
     // Otherwise look for an identifier.
     // TODO: Handle bitfield identifiers when evaluating in the value context.
-    auto value = LookupIdentifier(identifier, m_ctx_scope, m_use_dynamic,
-                                  nullptr);
+    auto value =
+        LookupIdentifier(identifier, m_ctx_scope, m_use_dynamic, nullptr);
+    if (!value)
+      value = LookupGlobalIdentifier(identifier, m_ctx_scope,
+                                     m_ctx_scope->CalculateTarget(),
+                                     m_use_dynamic, nullptr);
+
     if (!value) {
       BailOut(ErrorCode::kUndeclaredIdentifier,
               llvm::formatv("use of undeclared identifier '{0}'", identifier),
               loc);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
-    return std::make_unique<IdentifierNode>(loc, identifier, std::move(value),
-                                            /*is_rvalue*/ false,
-                                            IsContextVar(identifier));
-  } else if (m_dil_token.Is(Token::kw_this)) {
-    // Save the source location for the diagnostics message.
-    uint32_t loc = m_dil_token.GetLocation();
-    ConsumeToken();
-    auto value = LookupIdentifier("this", m_ctx_scope, m_use_dynamic);
-    if (!value) {
-      BailOut(ErrorCode::kUndeclaredIdentifier,
-              "invalid use of 'this' outside of a non-static member function",
-              loc);
-      return std::make_unique<ErrorNode>(bad_type);
-    }
-    // Special case for "this" pointer. As per C++ standard, it's a prvalue.
-    return std::make_unique<IdentifierNode>(loc, "this", std::move(value),
-                                            /*is_rvalue*/ true,
-                                            /*is_context_var*/ false);
-  } else if (m_dil_token.Is(Token::l_paren)) {
+    return std::make_unique<IdentifierNode>(
+        loc, identifier, m_use_dynamic, std::move(value),
+        /*is_rvalue*/ false, IsContextVar(identifier));
+  } else if (CurToken().Is(Token::l_paren)) {
     // Check in case this is an anonynmous namespace
     if (m_dil_lexer.LookAhead(1).Is(Token::identifier)
         && (((Token)m_dil_lexer.LookAhead(1)).GetSpelling() == "anonymous")
@@ -1626,47 +1665,50 @@ DILASTNodeUP DILParser::ParsePrimaryExpression() {
         && m_dil_lexer.LookAhead(3).Is(Token::r_paren)
         && m_dil_lexer.LookAhead(4).Is(Token::coloncolon)) {
       m_dil_lexer.Advance(4);
-      m_dil_token = m_dil_lexer.GetCurrentToken();
       std::string identifier = "(anonymous namespace)";
       Expect(Token::coloncolon);
       // Save the source location for the diagnostics message.
-      uint32_t loc = m_dil_token.GetLocation();
-      ConsumeToken();
-      assert ((m_dil_token.Is(Token::identifier) ||
-               m_dil_token.Is(Token::l_paren)) &&
-              "Expected an identifier or anonymous namespeace, but not found.");
+      uint32_t loc = CurToken().GetLocation();
+      m_dil_lexer.Advance();
+      assert(
+          (CurToken().Is(Token::identifier) || CurToken().Is(Token::l_paren)) &&
+          "Expected an identifier or anonymous namespeace, but not found.");
       std::string identifier2 = ParseNestedNameSpecifier();
       if (identifier2.empty()) {
         // There was only an identifer, no more levels of nesting. Or there
         // was an invalid expression starting with a left parenthesis.
         Expect(Token::identifier);
-        identifier2 = m_dil_token.GetSpelling();
-        ConsumeToken();
+        identifier2 = CurToken().GetSpelling();
+        m_dil_lexer.Advance();
       }
       identifier = identifier + "::" + identifier2;
       auto value = LookupIdentifier(identifier, m_ctx_scope, m_use_dynamic);
+      if (!value)
+        value = LookupGlobalIdentifier(identifier, m_ctx_scope,
+                                       m_ctx_scope->CalculateTarget(),
+                                       m_use_dynamic);
       if (!value) {
         BailOut(ErrorCode::kUndeclaredIdentifier,
                 llvm::formatv("use of undeclared identifier '{0}'", identifier),
                 loc);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
-      return std::make_unique<IdentifierNode>(loc, identifier, std::move(value),
-                                              /*is_rvalue*/ false,
-                                              IsContextVar(identifier));
+      return std::make_unique<IdentifierNode>(
+          loc, identifier, m_use_dynamic, std::move(value),
+          /* is_rvalue */ false, IsContextVar(identifier));
     } else {
-      ConsumeToken();
+      m_dil_lexer.Advance();
       auto expr = ParseExpression();
       Expect(Token::r_paren);
-      ConsumeToken();
+      m_dil_lexer.Advance();
       return expr;
     }
   }
 
   BailOut(ErrorCode::kInvalidExpressionSyntax,
-          llvm::formatv("Unexpected token: {0}", TokenDescription(m_dil_token)),
-          m_dil_token.GetLocation());
-  return std::make_unique<ErrorNode>(bad_type);
+          llvm::formatv("Unexpected token: {0}", CurToken()),
+          CurToken().GetLocation());
+  return std::make_unique<ErrorNode>();
 }
 
 // Parse a type_id.
@@ -1675,7 +1717,7 @@ DILASTNodeUP DILParser::ParsePrimaryExpression() {
 //    type_specifier_seq [abstract_declarator]
 //
 std::optional<CompilerType> DILParser::ParseTypeId(bool must_be_type_id) {
-  uint32_t type_loc = m_dil_token.GetLocation();
+  uint32_t type_loc = CurToken().GetLocation();
   TypeDeclaration type_decl;
   CompilerType bad_type;
 
@@ -1736,6 +1778,21 @@ std::optional<CompilerType> DILParser::ParseTypeId(bool must_be_type_id) {
       }
       return {};
     }
+
+    if (LookupGlobalIdentifier(type_decl.m_user_typename, m_ctx_scope,
+                               m_ctx_scope->CalculateTarget(), m_use_dynamic)) {
+      // Same-name identifiers should be preferred over typenames.
+      // TODO: Make type accessible with 'class', 'struct' and 'union' keywords.
+      if (must_be_type_id) {
+        BailOut(ErrorCode::kUndeclaredIdentifier,
+                llvm::formatv(
+                    "must use '{0}' tag to refer to type '{1}' in this scope",
+                    type.GetTypeTag(), type_decl.m_user_typename),
+                type_loc);
+        return bad_type;
+      }
+      return {};
+    }
   }
 
   //
@@ -1743,7 +1800,7 @@ std::optional<CompilerType> DILParser::ParseTypeId(bool must_be_type_id) {
   //    ptr_operator [abstract_declarator]
   //
   std::vector<DILParser::PtrOperator> ptr_operators;
-  while (IsPtrOperator(m_dil_token)) {
+  while (IsPtrOperator(CurToken())) {
     ptr_operators.push_back(ParsePtrOperator());
   }
   type = ResolveTypeDeclarators(type, ptr_operators);
@@ -1790,18 +1847,18 @@ void DILParser::ParseTypeSpecifierSeq(TypeDeclaration* type_decl) {
 // Returns TRUE if a type_specifier was successfully parsed at this location.
 //
 bool DILParser::ParseTypeSpecifier(TypeDeclaration* type_decl) {
-  if (IsCvQualifier(m_dil_token)) {
+  if (IsCvQualifier(CurToken())) {
     // Just ignore CV quialifiers, we don't use them in type casting.
-    ConsumeToken();
+    m_dil_lexer.Advance();
     return true;
   }
 
-  if (IsSimpleTypeSpecifierKeyword(m_dil_token)) {
+  if (IsSimpleTypeSpecifierKeyword(CurToken())) {
     // User-defined typenames can't be combined with builtin keywords.
     if (type_decl->m_is_user_type) {
       BailOut(ErrorCode::kInvalidOperandType,
               "cannot combine with previous declaration specifier",
-              m_dil_token.GetLocation());
+              CurToken().GetLocation());
       type_decl->m_has_error = true;
       return false;
     }
@@ -1814,7 +1871,7 @@ bool DILParser::ParseTypeSpecifier(TypeDeclaration* type_decl) {
       type_decl->m_has_error = true;
       return false;
     }
-    ConsumeToken();
+    m_dil_lexer.Advance();
     return true;
   }
 
@@ -1823,12 +1880,12 @@ bool DILParser::ParseTypeSpecifier(TypeDeclaration* type_decl) {
   {
     // Try parsing optional global scope operator.
     bool global_scope = false;
-    if (m_dil_token.Is(Token::coloncolon)) {
+    if (CurToken().Is(Token::coloncolon)) {
       global_scope = true;
-      ConsumeToken();
+      m_dil_lexer.Advance();
     }
 
-    uint32_t loc = m_dil_token.GetLocation();
+    uint32_t loc = CurToken().GetLocation();
 
     // Try parsing optional nested_name_specifier.
     auto nested_name_specifier = ParseNestedNameSpecifier();
@@ -1879,8 +1936,7 @@ bool DILParser::ParseTypeSpecifier(TypeDeclaration* type_decl) {
 std::string DILParser::ParseNestedNameSpecifier() {
   // The first token in nested_name_specifier is always an identifier, or
   // '(anonymous namespace)'.
-  if (m_dil_token.IsNot(Token::identifier) &&
-      m_dil_token.IsNot(Token::l_paren)) {
+  if (CurToken().IsNot(Token::identifier) && CurToken().IsNot(Token::l_paren)) {
     return "";
   }
 
@@ -1888,7 +1944,7 @@ std::string DILParser::ParseNestedNameSpecifier() {
   // the the string '(anonymous namespace)', which has a space in it (throwing
   // off normal parsing) and is not actually proper C++> Check to see if we're
   // looking at '(anonymous namespace)::...'
-  if (m_dil_token.Is(Token::l_paren)) {
+  if (CurToken().Is(Token::l_paren)) {
     // Look for all the pieces, in order:
     // l_paren 'anonymous' 'namespace' r_paren coloncolon
     if (m_dil_lexer.LookAhead(1).Is(Token::identifier)
@@ -1897,17 +1953,16 @@ std::string DILParser::ParseNestedNameSpecifier() {
         && m_dil_lexer.LookAhead(3).Is(Token::r_paren)
         && m_dil_lexer.LookAhead(4).Is(Token::coloncolon)) {
       m_dil_lexer.Advance(4);
-      m_dil_token = m_dil_lexer.GetCurrentToken();
 
-      assert ((m_dil_token.Is(Token::identifier)
-               || m_dil_token.Is(Token::l_paren)) &&
-              "Expected an identifier or anonymous namespace, but not found.");
+      assert(
+          (CurToken().Is(Token::identifier) || CurToken().Is(Token::l_paren)) &&
+          "Expected an identifier or anonymous namespace, but not found.");
       // Continue parsing the nested_namespace_specifier.
       std::string identifier2 = ParseNestedNameSpecifier();
       if (identifier2.empty()) {
         Expect(Token::identifier);
-        identifier2 = m_dil_token.GetSpelling();
-        ConsumeToken();
+        identifier2 = CurToken().GetSpelling();
+        m_dil_lexer.Advance();
       }
       return "(anonymous namespace)::" + identifier2;
     } else {
@@ -1919,11 +1974,10 @@ std::string DILParser::ParseNestedNameSpecifier() {
   // nested_name_specifier
   if (m_dil_lexer.LookAhead(1).Is(Token::coloncolon)) {
     // This nested_name_specifier is a single identifier.
-    std::string identifier = m_dil_token.GetSpelling();
+    std::string identifier = CurToken().GetSpelling();
     m_dil_lexer.Advance(1);
-    m_dil_token = m_dil_lexer.GetCurrentToken();
     Expect(Token::coloncolon);
-    ConsumeToken();
+    m_dil_lexer.Advance();
     // Continue parsing the nested_name_specifier.
     return identifier + "::" + ParseNestedNameSpecifier();
   }
@@ -1943,9 +1997,8 @@ std::string DILParser::ParseNestedNameSpecifier() {
     // If we did parse the type_name successfully and it's followed by the scope
     // operator ("::"), then this is indeed a nested_name_specifier. Continue
     // parsing nested_name_specifier.
-    if (!type_name.empty() && m_dil_token.Is(Token::coloncolon)) {
+    if (!type_name.empty() && CurToken().Is(Token::coloncolon)) {
       m_dil_lexer.Advance();
-      m_dil_token = m_dil_lexer.GetCurrentToken();
       // Continue parsing the nested_name_specifier.
       return type_name + "::" + ParseNestedNameSpecifier();
     }
@@ -1981,7 +2034,7 @@ std::string DILParser::ParseNestedNameSpecifier() {
 //
 std::string DILParser::ParseTypeName() {
   // Typename always starts with an identifier.
-  if (m_dil_token.IsNot(Token::identifier)) {
+  if (CurToken().IsNot(Token::identifier)) {
     return "";
   }
 
@@ -1989,33 +2042,31 @@ std::string DILParser::ParseTypeName() {
   // a simple_template_id.
   if (m_dil_lexer.LookAhead(1).Is(Token::less)) {
     // Parse the template_name. In this case it's just an identifier.
-    std::string template_name = m_dil_token.GetSpelling();
+    std::string template_name = CurToken().GetSpelling();
     m_dil_lexer.Advance(1);
-    m_dil_token = m_dil_lexer.GetCurrentToken();
     // Consume the "<" token.
-    ConsumeToken();
+    m_dil_lexer.Advance();
 
     // Short-circuit for missing template_argument_list.
-    if (m_dil_token.Is(Token::greater)) {
-      ConsumeToken();
+    if (CurToken().Is(Token::greater)) {
+      m_dil_lexer.Advance();
       return llvm::formatv("{0}<>", template_name);
     }
 
     // Try parsing template_argument_list.
     auto template_argument_list = ParseTemplateArgumentList();
 
-    if (m_dil_token.Is(Token::greater)) {
+    if (CurToken().Is(Token::greater)) {
       // Single closing angle bracket is a valid end of the template argument
       // list, just consume it.
-      ConsumeToken();
+      m_dil_lexer.Advance();
 
-    } else if (m_dil_token.Is(Token::greatergreater)) {
+    } else if (CurToken().Is(Token::greatergreater)) {
       // C++11 allows using ">>" in nested template argument lists and C++-style
       // casts. In this case we alter change the token type to ">", but don't
       // consume it -- it will be done on the outer level when completing the
       // outer template argument list or C++-style cast.
-      uint32_t loc = m_dil_token.GetLocation();
-      m_dil_token = Token(Token::greater, ">", loc);
+      uint32_t loc = CurToken().GetLocation();
       m_dil_lexer.InsertToken(Token(Token::greater, ">", loc+1));
 
     } else {
@@ -2028,8 +2079,8 @@ std::string DILParser::ParseTypeName() {
   }
 
   // Otherwise look for a class_name, enum_name or a typedef_name.
-  std::string identifier = m_dil_token.GetSpelling();
-  ConsumeToken();
+  std::string identifier = CurToken().GetSpelling();
+  m_dil_lexer.Advance();
 
   return identifier;
 }
@@ -2047,7 +2098,7 @@ std::string DILParser::ParseTemplateArgumentList() {
   do {
     // Eat the comma if this is not the first iteration.
     if (arguments.size() > 0) {
-      ConsumeToken();
+      m_dil_lexer.Advance();
     }
 
     // Try parsing a template_argument. If this fails, then this is actually not
@@ -2059,7 +2110,7 @@ std::string DILParser::ParseTemplateArgumentList() {
 
     arguments.push_back(argument);
 
-  } while (m_dil_token.Is(Token::comma));
+  } while (CurToken().Is(Token::comma));
 
   // Internally in LLDB/Clang nested template type names have extra spaces to
   // avoid having ">>". Add the extra space before the closing ">" if the
@@ -2114,13 +2165,13 @@ std::string DILParser::ParseTemplateArgument() {
     uint32_t save_token_idx = m_dil_lexer.GetCurrentTokenIdx();
 
     // Parse a numeric_literal.
-    if (m_dil_token.Is(Token::numeric_constant)) {
+    if (CurToken().Is(Token::numeric_constant)) {
       // TODO: Actually parse the literal, check if it's valid and
       // canonize it (e.g. 8LL -> 8).
-      std::string numeric_literal = m_dil_token.GetSpelling();
-      ConsumeToken();
+      std::string numeric_literal = CurToken().GetSpelling();
+      m_dil_lexer.Advance();
 
-      if (TokenEndsTemplateArgumentList(m_dil_token)) {
+      if (TokenEndsTemplateArgumentList(CurToken())) {
         return numeric_literal;
       }
     }
@@ -2139,7 +2190,7 @@ std::string DILParser::ParseTemplateArgument() {
 
     // If we've parsed the id_expression successfully and the next token can
     // finish the template_argument, then we're done here.
-    if (!id_expression.empty() && TokenEndsTemplateArgumentList(m_dil_token)) {
+    if (!id_expression.empty() && TokenEndsTemplateArgumentList(CurToken())) {
       return id_expression;
     }
     // Failed to parse a id_expression.
@@ -2149,7 +2200,7 @@ std::string DILParser::ParseTemplateArgument() {
   // TODO: Another valid option here is a constant_expression, but
   // we definitely don't want to support constant arithmetic like "Foo<1+2>".
   // We can probably use ParsePrimaryExpression here, but need to figure out the
-  // "stringification", since ParsePrimaryExpression returns DILASTNodeUP (and
+  // "stringification", since ParsePrimaryExpression returns ASTNodeUP (and
   // potentially a whole expression, not just a single constant.)
 
   // This is not a template_argument.
@@ -2163,12 +2214,12 @@ std::string DILParser::ParseTemplateArgument() {
 //    "&"
 //
 DILParser::PtrOperator DILParser::ParsePtrOperator() {
-  ExpectOneOf(Token::star, Token::amp);
+  ExpectOneOf(std::vector<Token::Kind>{Token::star, Token::amp});
 
   PtrOperator ptr_operator;
-  if (m_dil_token.Is(Token::star)) {
-    ptr_operator = std::make_tuple(Token::star, m_dil_token.GetLocation());
-    ConsumeToken();
+  if (CurToken().Is(Token::star)) {
+    ptr_operator = std::make_tuple(Token::star, CurToken().GetLocation());
+    m_dil_lexer.Advance();
 
     //
     //  cv_qualifier_seq:
@@ -2178,14 +2229,14 @@ DILParser::PtrOperator DILParser::ParsePtrOperator() {
     //    "const"
     //    "volatile"
     //
-    while (IsCvQualifier(m_dil_token)) {
+    while (IsCvQualifier(CurToken())) {
       // Just ignore CV quialifiers, we don't use them in type casting.
-      ConsumeToken();
+      m_dil_lexer.Advance();
     }
 
-  } else if (m_dil_token.Is(Token::amp)) {
-    ptr_operator = std::make_tuple(Token::amp, m_dil_token.GetLocation());
-    ConsumeToken();
+  } else if (CurToken().Is(Token::amp)) {
+    ptr_operator = std::make_tuple(Token::amp, CurToken().GetLocation());
+    m_dil_lexer.Advance();
   }
 
   return ptr_operator;
@@ -2207,9 +2258,9 @@ DILParser::PtrOperator DILParser::ParsePtrOperator() {
 std::string DILParser::ParseIdExpression() {
   // Try parsing optional global scope operator.
   bool global_scope = false;
-  if (m_dil_token.Is(Token::coloncolon)) {
+  if (CurToken().Is(Token::coloncolon)) {
     global_scope = true;
-    ConsumeToken();
+    m_dil_lexer.Advance();
   }
 
   // Try parsing optional nested_name_specifier.
@@ -2229,8 +2280,8 @@ std::string DILParser::ParseIdExpression() {
   // qualified_id production. Follow the second production rule.
   else if (global_scope) {
     Expect(Token::identifier);
-    std::string identifier = m_dil_token.GetSpelling();
-    ConsumeToken();
+    std::string identifier = CurToken().GetSpelling();
+    m_dil_lexer.Advance();
     return llvm::formatv("{0}{1}", global_scope ? "::" : "", identifier);
   }
 
@@ -2248,8 +2299,8 @@ std::string DILParser::ParseIdExpression() {
 //
 std::string DILParser::ParseUnqualifiedId() {
   Expect(Token::identifier);
-  std::string identifier = m_dil_token.GetSpelling();
-  ConsumeToken();
+  std::string identifier = CurToken().GetSpelling();
+  m_dil_lexer.Advance();
   return identifier;
 }
 
@@ -2258,10 +2309,10 @@ std::string DILParser::ParseUnqualifiedId() {
 //  numeric_literal:
 //    ? Token::numeric_constant ?
 //
-DILASTNodeUP DILParser::ParseNumericLiteral() {
+ASTNodeUP DILParser::ParseNumericLiteral() {
   Expect(Token::numeric_constant);
-  DILASTNodeUP numeric_constant = ParseNumericConstant();
-  ConsumeToken();
+  ASTNodeUP numeric_constant = ParseNumericConstant();
+  m_dil_lexer.Advance();
   return numeric_constant;
 }
 
@@ -2271,37 +2322,37 @@ DILASTNodeUP DILParser::ParseNumericLiteral() {
 //    "true"
 //    "false"
 //
-DILASTNodeUP DILParser::ParseBooleanLiteral() {
-  ExpectOneOf(Token::kw_true, Token::kw_false);
-  uint32_t loc = m_dil_token.GetLocation();
-  bool literal_value = m_dil_token.Is(Token::kw_true);
-  ConsumeToken();
+ASTNodeUP DILParser::ParseBooleanLiteral() {
+  ExpectOneOf(std::vector<Token::Kind>{Token::kw_true, Token::kw_false});
+  uint32_t loc = CurToken().GetLocation();
+  bool literal_value = CurToken().Is(Token::kw_true);
+  m_dil_lexer.Advance();
   Scalar scalar_value(static_cast<int>(literal_value));
   return std::make_unique<ScalarLiteralNode>(
       loc, GetBasicType(m_ctx_scope, lldb::eBasicTypeBool), scalar_value);
 }
 
-DILASTNodeUP DILParser::ParseCharLiteral() {
-  ExpectOneOf(Token::char_constant,
-              Token::wide_char_constant,
-              Token::utf8_char_constant);
-  uint32_t loc = m_dil_token.GetLocation();
+ASTNodeUP DILParser::ParseCharLiteral() {
+  ExpectOneOf(std::vector<Token::Kind>{Token::char_constant,
+                                       Token::wide_char_constant,
+                                       Token::utf8_char_constant});
+  uint32_t loc = CurToken().GetLocation();
 
-  std::string token_spelling = m_dil_token.GetSpelling();
+  std::string token_spelling = CurToken().GetSpelling();
 
   const char* token_begin = token_spelling.c_str();
   dil::CharLiteralParser char_literal(token_begin,
-                                      token_begin + token_spelling.size(),
-                                      loc, m_dil_lexer, m_dil_token.GetKind());
+                                      token_begin + token_spelling.size(), loc,
+                                      m_dil_lexer, CurToken().GetKind());
 
   if (char_literal.hadError()) {
     // TODO: Add new ErrorCode kInvalidCharLiteral and use it
     BailOut(ErrorCode::kInvalidNumericLiteral,
             llvm::formatv("Failed to parse token as char-constant: {0}",
-                          TokenDescription(m_dil_token)),
-            m_dil_token.GetLocation());
+                          CurToken()),
+            CurToken().GetLocation());
     CompilerType bad_type;
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   auto ctx_basic_type = GetBasicType(m_ctx_scope, PickCharType(char_literal));
@@ -2311,7 +2362,7 @@ DILASTNodeUP DILParser::ParseCharLiteral() {
   llvm::APInt literal_value(byte_size * CHAR_BIT,
                             char_literal.getValue());
 
-  ConsumeToken();
+  m_dil_lexer.Advance();
   Scalar scalar_value(literal_value);
   return std::make_unique<ScalarLiteralNode>(loc, ctx_basic_type, scalar_value);
 }
@@ -2321,57 +2372,56 @@ DILASTNodeUP DILParser::ParseCharLiteral() {
 //  pointer_literal:
 //    "nullptr"
 //
-DILASTNodeUP DILParser::ParsePointerLiteral() {
+ASTNodeUP DILParser::ParsePointerLiteral() {
   Expect(Token::kw_nullptr);
-  uint32_t loc = m_dil_token.GetLocation();
-  ConsumeToken();
+  uint32_t loc = CurToken().GetLocation();
+  m_dil_lexer.Advance();
   llvm::APInt raw_value(type_width<uintmax_t>(), 0);
   Scalar scalar_value(raw_value);
   return std::make_unique<ScalarLiteralNode>(
       loc, GetBasicType(m_ctx_scope, lldb::eBasicTypeNullPtr), scalar_value);
 }
 
-DILASTNodeUP DILParser::ParseNumericConstant() {
+ASTNodeUP DILParser::ParseNumericConstant() {
   CompilerType bad_type;
   // Parse numeric constant, it can be either integer or float.
-  std::string tok_spelling = m_dil_token.GetSpelling();
+  std::string tok_spelling = CurToken().GetSpelling();
   llvm::StringRef tok_spelling_ref(tok_spelling);
 
   lldb::TargetSP target_sp = m_ctx_scope->CalculateTarget();
-  dil::NumericLiteralParser literal(
-      tok_spelling_ref, m_dil_token.GetLocation(), /*AllowHalfType=*/true,
-      m_dil_lexer,
-      /*AllowMicrosoftExt=*/true);
+  dil::NumericLiteralParser literal(tok_spelling_ref, CurToken().GetLocation(),
+                                    /*AllowHalfType=*/true, m_dil_lexer,
+                                    /*AllowMicrosoftExt=*/true);
 
   if (literal.hadError) {
-    BailOut(
-        ErrorCode::kInvalidNumericLiteral,
-        "Failed to parse token as numeric-constant: " +
-        TokenDescription(m_dil_token),
-        m_dil_token.GetLocation());
-    return std::make_unique<ErrorNode>(bad_type);
+    BailOut(ErrorCode::kInvalidNumericLiteral,
+            llvm::formatv("Failed to parse token as numeric-constant: {0}",
+                          CurToken()),
+            CurToken().GetLocation());
+    return std::make_unique<ErrorNode>();
   }
 
   // Check for floating-literal and integer-literal. Fail on anything else (i.e.
   // fixed-point literal, who needs them anyway??).
+  Token token = CurToken();
   if (literal.isFloatingLiteral()) {
-    return ParseFloatingLiteral(literal, m_dil_token);
+    return ParseFloatingLiteral(literal, token);
   }
   if (literal.isIntegerLiteral()) {
-    return ParseIntegerLiteral(literal, m_dil_token);
+    return ParseIntegerLiteral(literal, token);
   }
 
   // Don't care about anything else.
   BailOut(ErrorCode::kInvalidNumericLiteral,
-          "numeric-constant should be either float or integer literal: " +
-              TokenDescription(m_dil_token),
-          m_dil_token.GetLocation());
-  return std::make_unique<ErrorNode>(bad_type);
+          llvm::formatv(
+              "numeric-constant should be either float or integer literal: {0}",
+              CurToken()),
+          CurToken().GetLocation());
+  return std::make_unique<ErrorNode>();
 }
 
-DILASTNodeUP DILParser::ParseFloatingLiteral(
-    dil::NumericLiteralParser& literal,
-    Token& token) {
+ASTNodeUP DILParser::ParseFloatingLiteral(dil::NumericLiteralParser &literal,
+                                          Token &token) {
   const llvm::fltSemantics& format = literal.isFloat
                                          ? llvm::APFloat::IEEEsingle()
                                          : llvm::APFloat::IEEEdouble();
@@ -2384,11 +2434,10 @@ DILASTNodeUP DILParser::ParseFloatingLiteral(
   if ((result & llvm::APFloat::opOverflow) ||
       ((result & llvm::APFloat::opUnderflow) && raw_value.isZero())) {
     BailOut(ErrorCode::kInvalidNumericLiteral,
-            llvm::formatv("float underflow/overflow happened: {0}",
-                          TokenDescription(token)),
+            llvm::formatv("float underflow/overflow happened: {0}", token),
             token.GetLocation());
     CompilerType bad_type;
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   auto basic_type =
@@ -2398,8 +2447,8 @@ DILASTNodeUP DILParser::ParseFloatingLiteral(
       token.GetLocation(), GetBasicType(m_ctx_scope, basic_type), scalar_value);
 }
 
-DILASTNodeUP DILParser::ParseIntegerLiteral(dil::NumericLiteralParser& literal,
-                                            Token& token) {
+ASTNodeUP DILParser::ParseIntegerLiteral(dil::NumericLiteralParser &literal,
+                                         Token &token) {
   // Create a value big enough to fit all valid numbers.
   llvm::APInt raw_value(type_width<uintmax_t>(), 0);
 
@@ -2407,10 +2456,10 @@ DILASTNodeUP DILParser::ParseIntegerLiteral(dil::NumericLiteralParser& literal,
     BailOut(ErrorCode::kInvalidNumericLiteral,
             llvm::formatv("integer literal is too large to be represented in "
                           "any integer type: {0}",
-                          TokenDescription(token)),
+                          token),
             token.GetLocation());
     CompilerType bad_type;
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   auto [type, is_unsigned] = PickIntegerType(m_ctx_scope, literal, raw_value);
@@ -2436,38 +2485,38 @@ DILASTNodeUP DILParser::ParseIntegerLiteral(dil::NumericLiteralParser& literal,
 //  builtin_func_argument:
 //    expression
 //
-DILASTNodeUP DILParser::ParseBuiltinFunction(
-    uint32_t loc, std::unique_ptr<BuiltinFunctionDef> func_def) {
+ASTNodeUP
+DILParser::ParseBuiltinFunction(uint32_t loc,
+                                std::unique_ptr<BuiltinFunctionDef> func_def) {
   Expect(Token::l_paren);
-  ConsumeToken();
+  m_dil_lexer.Advance();
 
-  std::vector<DILASTNodeUP> arguments;
+  std::vector<ASTNodeUP> arguments;
   CompilerType bad_type;
 
-  if (m_dil_token.Is(Token::r_paren)) {
+  if (CurToken().Is(Token::r_paren)) {
     // Empty argument list, nothing to do here.
-    ConsumeToken();
+    m_dil_lexer.Advance();
   } else {
     // Non-empty argument list, parse all the arguments.
     do {
       // Eat the comma if this is not the first iteration.
       if (arguments.size() > 0) {
-        ConsumeToken();
+        m_dil_lexer.Advance();
       }
 
       // Parse a builtin_func_argument. If failed to parse, bail out early and
       // don't try parsing the rest of the arguments.
       auto argument = ParseExpression();
       if (llvm::isa<ErrorNode>(argument)) {
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
 
       arguments.push_back(std::move(argument));
-
-    } while (m_dil_token.Is(Token::comma));
+    } while (CurToken().Is(Token::comma));
 
     Expect(Token::r_paren);
-    ConsumeToken();
+    m_dil_lexer.Advance();
   }
 
   // Check we have the correct number of arguments.
@@ -2479,7 +2528,7 @@ DILASTNodeUP DILParser::ParseBuiltinFunction(
                 func_def->m_name, func_def->m_arguments.size(),
                 arguments.size()),
             loc);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   // Now check that all arguments are correct types and perform implicit
@@ -2494,7 +2543,7 @@ DILASTNodeUP DILParser::ParseBuiltinFunction(
     arguments[i] = InsertImplicitConversion(std::move(arguments[i]),
                                             func_def->m_arguments[i]);
     if (llvm::isa<ErrorNode>(arguments[i])) {
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
   }
 
@@ -2502,8 +2551,8 @@ DILASTNodeUP DILParser::ParseBuiltinFunction(
       loc, func_def->m_return_type, func_def->m_name, std::move(arguments));
 }
 
-DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
-                                      uint32_t location) {
+ASTNodeUP DILParser::BuildCStyleCast(CompilerType type, ASTNodeUP rhs,
+                                     uint32_t location) {
   CStyleCastKind cast_kind = dil::CStyleCastKind::eNone;
   TypePromotionCastKind promo_kind = dil::TypePromotionCastKind::eNone;
   CompilerType bad_type;
@@ -2526,7 +2575,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
                               rhs_type.TypeDescription(),
                               type.TypeDescription()),
                 location);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
       // Casting pointer to bool is valid. Otherwise check if the result type
       // is at least as big as the pointer size.
@@ -2542,7 +2591,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
                     "cast from pointer to smaller type {0} loses information",
                     type.TypeDescription()),
                 location);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
     } else if (!rhs_type.IsScalarType() && !rhs_type.IsEnumerationType()) {
       // Otherwise accept only arithmetic types and enums.
@@ -2551,7 +2600,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
                   "cannot convert {0} to {1} without a conversion operator",
                   rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
     promo_kind = TypePromotionCastKind::eArithmetic;
 
@@ -2562,7 +2611,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
               llvm::formatv("C-style cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
     cast_kind = CStyleCastKind::eEnumeration;
 
@@ -2575,7 +2624,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
               llvm::formatv("cannot cast from type {0} to pointer type {1}",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
     promo_kind = TypePromotionCastKind::ePointer;
 
@@ -2586,7 +2635,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
               llvm::formatv("C-style cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
     cast_kind = CStyleCastKind::eNullptr;
 
@@ -2597,7 +2646,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
               llvm::formatv("C-style cast from rvalue to reference type {0}",
                             type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
     cast_kind = CStyleCastKind::eReference;
 
@@ -2607,7 +2656,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
             llvm::formatv("casting of {0} to {1} is not implemented yet",
                           rhs_type.TypeDescription(), type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   if (cast_kind != dil::CStyleCastKind::eNone)
@@ -2615,9 +2664,8 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
   return std::make_unique<CStyleCastNode>(location, type, std::move(rhs), promo_kind);
 }
 
-DILASTNodeUP DILParser::BuildCxxCast(Token::Kind kind, CompilerType type,
-                                   DILASTNodeUP rhs,
-                                   uint32_t location) {
+ASTNodeUP DILParser::BuildCxxCast(Token::Kind kind, CompilerType type,
+                                  ASTNodeUP rhs, uint32_t location) {
   assert((kind == Token::kw_static_cast ||
           kind == Token::kw_dynamic_cast ||
           kind == Token::kw_reinterpret_cast) &&
@@ -2636,8 +2684,8 @@ DILASTNodeUP DILParser::BuildCxxCast(Token::Kind kind, CompilerType type,
   return BuildCStyleCast(type, std::move(rhs), location);
 }
 
-DILASTNodeUP DILParser::BuildCxxStaticCast(CompilerType type, DILASTNodeUP rhs,
-                                         uint32_t location) {
+ASTNodeUP DILParser::BuildCxxStaticCast(CompilerType type, ASTNodeUP rhs,
+                                        uint32_t location) {
   auto rhs_type = rhs->GetDereferencedResultType();
 
   // Perform implicit array-to-pointer conversion.
@@ -2670,13 +2718,12 @@ DILASTNodeUP DILParser::BuildCxxStaticCast(CompilerType type, DILASTNodeUP rhs,
                         rhs_type.TypeDescription(), type.TypeDescription()),
           location);
   CompilerType bad_type;
-  return std::make_unique<ErrorNode>(bad_type);
+  return std::make_unique<ErrorNode>();
 }
 
-DILASTNodeUP DILParser::BuildCxxStaticCastToScalar(CompilerType type,
-                                                 DILASTNodeUP rhs,
-                                                 uint32_t location)
-{
+ASTNodeUP DILParser::BuildCxxStaticCastToScalar(CompilerType type,
+                                                ASTNodeUP rhs,
+                                                uint32_t location) {
   auto rhs_type = rhs->GetDereferencedResultType();
   CompilerType bad_type;
 
@@ -2687,7 +2734,7 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToScalar(CompilerType type,
               llvm::formatv("static_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
   } else if (!rhs_type.IsScalarType() && !rhs_type.IsEnumerationType()) {
     // Otherwise accept only arithmetic types and enums.
@@ -2696,7 +2743,7 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToScalar(CompilerType type,
         llvm::formatv("cannot convert {0} to {1} without a conversion operator",
                       rhs_type.TypeDescription(), type.TypeDescription()),
         location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   return std::make_unique<CxxStaticCastNode>(location, type, std::move(rhs),
@@ -2704,8 +2751,8 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToScalar(CompilerType type,
                                              /*is_rvalue*/ true);
 }
 
-DILASTNodeUP DILParser::BuildCxxStaticCastToEnum(CompilerType type, DILASTNodeUP rhs,
-                                               uint32_t location) {
+ASTNodeUP DILParser::BuildCxxStaticCastToEnum(CompilerType type, ASTNodeUP rhs,
+                                              uint32_t location) {
   auto rhs_type = rhs->GetDereferencedResultType();
 
   if (!rhs_type.IsScalarType() && !rhs_type.IsEnumerationType()) {
@@ -2714,7 +2761,7 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToEnum(CompilerType type, DILASTNodeUP
                           rhs_type.TypeDescription(), type.TypeDescription()),
             location);
     CompilerType bad_type;
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   return std::make_unique<CxxStaticCastNode>(location, type, std::move(rhs),
@@ -2722,9 +2769,9 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToEnum(CompilerType type, DILASTNodeUP
                                              /*is_rvalue*/ true);
 }
 
-DILASTNodeUP DILParser::BuildCxxStaticCastToPointer(
-    CompilerType type, DILASTNodeUP rhs, uint32_t location)
-{
+ASTNodeUP DILParser::BuildCxxStaticCastToPointer(CompilerType type,
+                                                 ASTNodeUP rhs,
+                                                 uint32_t location) {
   CompilerType bad_type;
   auto rhs_type = rhs->GetDereferencedResultType();
 
@@ -2742,14 +2789,14 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToPointer(
               llvm::formatv("static_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
   } else if (!rhs_type.IsNullPtrType() && !rhs->is_literal_zero()) {
     BailOut(ErrorCode::kInvalidOperandType,
             llvm::formatv("cannot cast from type {0} to pointer type '{1}'",
                           rhs_type.TypeDescription(), type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   return std::make_unique<CxxStaticCastNode>(location, type, std::move(rhs),
@@ -2757,10 +2804,9 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToPointer(
                                              /*is_rvalue*/ true);
 }
 
-DILASTNodeUP DILParser::BuildCxxStaticCastToNullPtr(CompilerType type,
-                                                  DILASTNodeUP rhs,
-                                                  uint32_t location)
-{
+ASTNodeUP DILParser::BuildCxxStaticCastToNullPtr(CompilerType type,
+                                                 ASTNodeUP rhs,
+                                                 uint32_t location) {
   auto rhs_type = rhs->GetDereferencedResultType();
 
   if (!rhs_type.IsNullPtrType() && !rhs->is_literal_zero()) {
@@ -2769,7 +2815,7 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToNullPtr(CompilerType type,
                           rhs_type.TypeDescription(), type.TypeDescription()),
             location);
     CompilerType bad_type;
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   return std::make_unique<CxxStaticCastNode>(location, type, std::move(rhs),
@@ -2777,10 +2823,9 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToNullPtr(CompilerType type,
                                              /*is_rvalue*/ true);
 }
 
-DILASTNodeUP DILParser::BuildCxxStaticCastToReference(
-    CompilerType type,
-    DILASTNodeUP rhs,
-    uint32_t location) {
+ASTNodeUP DILParser::BuildCxxStaticCastToReference(CompilerType type,
+                                                   ASTNodeUP rhs,
+                                                   uint32_t location) {
   CompilerType bad_type;
   auto rhs_type = rhs->GetDereferencedResultType();
   auto type_deref = type.GetNonReferenceType();
@@ -2791,7 +2836,7 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToReference(
                           "type {1} is not implemented yet",
                           rhs_type.TypeDescription(), type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   if (type_deref.CompareTypes(rhs_type)) {
@@ -2808,11 +2853,12 @@ DILASTNodeUP DILParser::BuildCxxStaticCastToReference(
           llvm::formatv("static_cast from {0} to {1} is not implemented yet",
                         rhs_type.TypeDescription(), type.TypeDescription()),
           location);
-  return std::make_unique<ErrorNode>(bad_type);
+  return std::make_unique<ErrorNode>();
 }
 
-DILASTNodeUP DILParser::BuildCxxStaticCastForInheritedTypes(
-    CompilerType type, DILASTNodeUP rhs, uint32_t location) {
+ASTNodeUP DILParser::BuildCxxStaticCastForInheritedTypes(CompilerType type,
+                                                         ASTNodeUP rhs,
+                                                         uint32_t location) {
   assert((type.IsPointerType() || type.IsReferenceType()) &&
          "target type should either be a pointer or a reference");
 
@@ -2858,7 +2904,7 @@ DILASTNodeUP DILParser::BuildCxxStaticCastForInheritedTypes(
                             rhs_type.TypeDescription(), type.TypeDescription(),
                             virtual_base.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
 
     return std::make_unique<CxxStaticCastNode>(location, type, std::move(rhs),
@@ -2870,11 +2916,11 @@ DILASTNodeUP DILParser::BuildCxxStaticCastForInheritedTypes(
                         "related by inheritance, is not allowed",
                         rhs_type.TypeDescription(), type.TypeDescription()),
           location);
-  return std::make_unique<ErrorNode>(bad_type);
+  return std::make_unique<ErrorNode>();
 }
 
-DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP rhs,
-                                              uint32_t location) {
+ASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, ASTNodeUP rhs,
+                                             uint32_t location) {
   CompilerType bad_type;
   auto rhs_type = rhs->GetDereferencedResultType();
   bool is_rvalue = true;
@@ -2886,7 +2932,7 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
               llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
 
     // Perform implicit conversions.
@@ -2910,7 +2956,7 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
                     "cast from pointer to smaller type {0} loses information",
                     type.TypeDescription()),
                 location);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
     } else if (type.IsTypedefType() || rhs_type.IsTypedefType()) {
       CompilerType base_type = type.IsTypedefType() ? type.GetTypedefedType()
@@ -2923,7 +2969,7 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
                 llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                               rhs_type.TypeDescription(), type.TypeDescription()),
                 location);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
     } else if (!type.CompareTypes(rhs_type)) {
       // Integral type can be converted to its own type.
@@ -2931,7 +2977,7 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
               llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
   } else if (type.IsEnumerationType()) {
     // Enumeration type can be converted to its own type.
@@ -2944,7 +2990,7 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
               llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
 
   } else if (type.IsPointerType()) {
@@ -2957,7 +3003,7 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
               llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
 
   } else if (type.IsNullPtrType()) {
@@ -2966,7 +3012,7 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
             llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                           rhs_type.TypeDescription(), type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
 
   } else if (type.IsReferenceType()) {
     // L-values can be converted to any reference type.
@@ -2976,7 +3022,7 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
           llvm::formatv("reinterpret_cast from rvalue to reference type {0}",
                         type.TypeDescription()),
           location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
     // Casting to reference types gives an L-value result.
     is_rvalue = false;
@@ -2987,15 +3033,15 @@ DILASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, DILASTNodeUP 
             llvm::formatv("casting of {0} to {1} is not implemented yet",
                           rhs_type.TypeDescription(), type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   return std::make_unique<CxxReinterpretCastNode>(location, type,
                                                   std::move(rhs), is_rvalue);
 }
 
-DILASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, DILASTNodeUP rhs,
-                                          uint32_t location) {
+ASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, ASTNodeUP rhs,
+                                         uint32_t location) {
   CompilerType pointee_type;
   CompilerType bad_type;
   if (type.IsPointerType()) {
@@ -3010,7 +3056,7 @@ DILASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, DILASTNodeUP rhs,
                       "must be a reference or pointer type to a defined class",
                       type.TypeDescription()),
         location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
   // Dynamic casts are allowed only for record types.
   if (!pointee_type.IsRecordType()) {
@@ -3018,7 +3064,7 @@ DILASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, DILASTNodeUP rhs,
         ErrorCode::kInvalidOperandType,
         llvm::formatv("{0} is not a class type", pointee_type.TypeDescription()),
         location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   auto expr_type = rhs->result_type();
@@ -3032,7 +3078,7 @@ DILASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, DILASTNodeUP rhs,
             llvm::formatv("cannot use dynamic_cast to convert from {0} to {1}",
                           expr_type.TypeDescription(), type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
   // Dynamic casts are allowed only for record types.
   if (!expr_type.IsRecordType()) {
@@ -3040,7 +3086,7 @@ DILASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, DILASTNodeUP rhs,
         ErrorCode::kInvalidOperandType,
         llvm::formatv("{0} is not a class type", expr_type.TypeDescription()),
         location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   // Expr type must be polymorphic.
@@ -3048,18 +3094,18 @@ DILASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, DILASTNodeUP rhs,
     BailOut(ErrorCode::kInvalidOperandType,
             llvm::formatv("{0} is not polymorphic", expr_type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   // LLDB doesn't support dynamic_cast in the expression evaluator. We disable
   // it too to match the behaviour, but theoretically it can be implemented.
   BailOut(ErrorCode::kInvalidOperandType,
           "dynamic_cast is not supported in this context", location);
-  return std::make_unique<ErrorNode>(bad_type);
+  return std::make_unique<ErrorNode>();
 }
 
-DILASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, DILASTNodeUP rhs,
-                                uint32_t location) {
+ASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, ASTNodeUP rhs,
+                                  uint32_t location) {
   CompilerType result_type;
   auto rhs_type = rhs->GetDereferencedResultType();
   CompilerType bad_type;
@@ -3074,7 +3120,7 @@ DILASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, DILASTNodeUP rhs,
       } else {
         bool synthetic_child = false;
         lldb::ValueObjectSP rhs_valobj_sp;
-        DILASTNode *ast_node = rhs.get();
+        ASTNode *ast_node = rhs.get();
         if (llvm::isa<IdentifierNode>(ast_node)) {
           IdentifierNode *id_node =
               (IdentifierNode*)ast_node;
@@ -3087,9 +3133,10 @@ DILASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, DILASTNodeUP rhs,
               rhs_type = child_sp->GetCompilerType().GetPointerType();
               std::unique_ptr<IdentifierInfo> new_info =
                   IdentifierInfo::FromValue(*child_sp);
-              DILASTNodeUP new_rhs = std::make_unique<IdentifierNode>(
-                  id_node->GetLocation(), id_node->name(), std::move(new_info),
-                  id_node->is_rvalue(), id_node->is_context_var());
+              ASTNodeUP new_rhs = std::make_unique<IdentifierNode>(
+                  id_node->GetLocation(), id_node->GetName(), m_use_dynamic,
+                  std::move(new_info), id_node->is_rvalue(),
+                  id_node->is_context_var());
               rhs = std::move(new_rhs);
               result_type = rhs->GetDereferencedResultType();
               synthetic_child = true;
@@ -3114,8 +3161,8 @@ DILASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, DILASTNodeUP rhs,
               llvm::formatv("indirection requires pointer operand ({0} invalid)",
                             rhs_type.TypeDescription()),
               location);
-          return std::make_unique<ErrorNode>(bad_type);
-	}
+          return std::make_unique<ErrorNode>();
+        }
       }
       break;
     }
@@ -3126,12 +3173,12 @@ DILASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, DILASTNodeUP rhs,
             llvm::formatv("cannot take the address of an rvalue of type {0}",
                           rhs_type.TypeDescription()),
             location);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
       if (rhs->is_bitfield()) {
         BailOut(ErrorCode::kInvalidOperandType,
                 "address of bit-field requested", location);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
       result_type = rhs_type.GetPointerType();
       break;
@@ -3177,18 +3224,17 @@ DILASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, DILASTNodeUP rhs,
             llvm::formatv(kInvalidOperandsToUnaryExpression,
                           rhs_type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   return std::make_unique<UnaryOpNode>(location, result_type, kind,
                                        std::move(rhs));
 }
 
-DILASTNodeUP DILParser::BuildBinaryOp(BinaryOpKind kind, DILASTNodeUP lhs,
-                                 DILASTNodeUP rhs,
-                                 uint32_t location) {
+ASTNodeUP DILParser::BuildBinaryOp(BinaryOpKind kind, ASTNodeUP lhs,
+                                   ASTNodeUP rhs, uint32_t location) {
   // TODO: Get the "original" type (i.e. the one before implicit casts)
-  // from the DILASTNodeUP.
+  // from the ASTNodeUP.
   auto orig_lhs_type = lhs->GetDereferencedResultType();
   auto orig_rhs_type = rhs->GetDereferencedResultType();
 
@@ -3256,7 +3302,7 @@ DILASTNodeUP DILParser::BuildBinaryOp(BinaryOpKind kind, DILASTNodeUP lhs,
       // Shortcut for the case when the implicit conversion is not possible.
       if (llvm::isa<ErrorNode>(rhs)) {
         CompilerType bad_type;
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
       comp_assign_type = rhs->GetDereferencedResultType();
       break;
@@ -3312,8 +3358,8 @@ DILASTNodeUP DILParser::BuildBinaryOp(BinaryOpKind kind, DILASTNodeUP lhs,
       // Check to see if either lhs or rhs is an IdentifierNode. If so,
       // extract the valobj from the IdentifierNode & pass it to
       // BinaryOpNode (for help with looking up members of dynamic types).
-      const DILASTNode* lhs_ast_node = lhs.get();
-      const DILASTNode* rhs_ast_node = rhs.get();
+      const ASTNode *lhs_ast_node = lhs.get();
+      const ASTNode *rhs_ast_node = rhs.get();
       lldb::ValueObjectSP valobj_sp;
       if (llvm::isa<IdentifierNode>(lhs_ast_node)) {
         const IdentifierNode *id_node =
@@ -3339,12 +3385,11 @@ DILASTNodeUP DILParser::BuildBinaryOp(BinaryOpKind kind, DILASTNodeUP lhs,
                         orig_rhs_type.TypeDescription()),
           location);
   CompilerType bad_type;
-  return std::make_unique<ErrorNode>(bad_type);
+  return std::make_unique<ErrorNode>();
 }
 
-DILASTNodeUP DILParser::BuildTernaryOp(DILASTNodeUP cond, DILASTNodeUP lhs,
-                                  DILASTNodeUP rhs,
-                                  uint32_t location) {
+ASTNodeUP DILParser::BuildTernaryOp(ASTNodeUP cond, ASTNodeUP lhs,
+                                    ASTNodeUP rhs, uint32_t location) {
   CompilerType bad_type;
   // First check if the condition contextually converted to bool.
   auto cond_type = cond->GetDereferencedResultType();
@@ -3353,7 +3398,7 @@ DILASTNodeUP DILParser::BuildTernaryOp(DILASTNodeUP cond, DILASTNodeUP lhs,
         ErrorCode::kInvalidOperandType,
         llvm::formatv(kValueIsNotConvertibleToBool, cond_type.TypeDescription()),
         location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   auto lhs_type = lhs->GetDereferencedResultType();
@@ -3430,17 +3475,17 @@ DILASTNodeUP DILParser::BuildTernaryOp(DILASTNodeUP cond, DILASTNodeUP lhs,
           llvm::formatv("incompatible operand types ({0} and {1})",
                         lhs_type.TypeDescription(), rhs_type.TypeDescription()),
           location);
-  return std::make_unique<ErrorNode>(bad_type);
+  return std::make_unique<ErrorNode>();
 }
 
-DILASTNodeUP DILParser::BuildBinarySubscript(DILASTNodeUP lhs, DILASTNodeUP rhs,
-                                        uint32_t location) {
+ASTNodeUP DILParser::BuildBinarySubscript(ASTNodeUP lhs, ASTNodeUP rhs,
+                                          uint32_t location) {
   // C99 6.5.2.1p2: the expression e1[e2] is by definition precisely
   // equivalent to the expression *((e1)+(e2)).
   // We need to figure out which expression is "base" and which is "index".
 
-  DILASTNodeUP base;
-  DILASTNodeUP index;
+  ASTNodeUP base;
+  ASTNodeUP index;
   CompilerType bad_type;
 
   auto lhs_type = lhs->GetDereferencedResultType();
@@ -3460,7 +3505,7 @@ DILASTNodeUP DILParser::BuildBinarySubscript(DILASTNodeUP lhs, DILASTNodeUP rhs,
     index = std::move(lhs);
   } else {
     // Check to see if this might be a synthetic value.
-    const DILASTNode* ast_node = lhs.get();
+    const ASTNode *ast_node = lhs.get();
     if (llvm::isa<IdentifierNode>(ast_node)) {
       const IdentifierNode* id_node =
           static_cast<const IdentifierNode*>(ast_node);
@@ -3471,12 +3516,12 @@ DILASTNodeUP DILParser::BuildBinarySubscript(DILASTNodeUP lhs, DILASTNodeUP rhs,
       } else {
         BailOut(ErrorCode::kInvalidOperandType,
                 "subscripted value is not an array or pointer", location);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
     } else {
       BailOut(ErrorCode::kInvalidOperandType,
               "subscripted value is not an array or pointer", location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
   }
 
@@ -3488,14 +3533,14 @@ DILASTNodeUP DILParser::BuildBinarySubscript(DILASTNodeUP lhs, DILASTNodeUP rhs,
   if (!index_type.IsIntegerOrUnscopedEnumerationType()) {
     BailOut(ErrorCode::kInvalidOperandType, "array subscript is not an integer",
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   auto base_type = base->GetDereferencedResultType();
   if (base_type.IsPointerToVoid()) {
     BailOut(ErrorCode::kInvalidOperandType,
             "subscript of pointer to incomplete type 'void'", location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   return std::make_unique<ArraySubscriptNode>(
@@ -3503,15 +3548,14 @@ DILASTNodeUP DILParser::BuildBinarySubscript(DILASTNodeUP lhs, DILASTNodeUP rhs,
       std::move(index));
 }
 
-DILASTNodeUP DILParser::BuildMemberOf(DILASTNodeUP lhs, std::string member_id,
-                                     bool is_arrow,
-                                     uint32_t location) {
+ASTNodeUP DILParser::BuildMemberOf(ASTNodeUP lhs, std::string member_id,
+                                   bool is_arrow, uint32_t location) {
   CompilerType bad_type;
   auto lhs_type = lhs->GetDereferencedResultType();
   lldb::ValueObjectSP lhs_valobj_sp;
   lldb::ValueObjectSP deref_sp;
 
-  const DILASTNode *ast_node = lhs.get();
+  const ASTNode *ast_node = lhs.get();
   ValueObject *valobj = ast_node->valobj();
   if (valobj)
     lhs_valobj_sp = valobj->GetSP();
@@ -3529,7 +3573,7 @@ DILASTNodeUP DILParser::BuildMemberOf(DILASTNodeUP lhs, std::string member_id,
                               "did you mean to use '.'?",
                               lhs_type.TypeDescription()),
                 location);
-        return std::make_unique<ErrorNode>(bad_type);
+        return std::make_unique<ErrorNode>();
       }
     } else if (lhs_type.IsArrayType()) {
       // If LHS is an array, convert it to pointer.
@@ -3547,7 +3591,7 @@ DILASTNodeUP DILParser::BuildMemberOf(DILASTNodeUP lhs, std::string member_id,
                             "did you mean to use '->'?",
                             lhs_type.TypeDescription()),
               location);
-      return std::make_unique<ErrorNode>(bad_type);
+      return std::make_unique<ErrorNode>();
     }
   }
 
@@ -3558,7 +3602,7 @@ DILASTNodeUP DILParser::BuildMemberOf(DILASTNodeUP lhs, std::string member_id,
                 "member reference base type {0} is not a structure or union",
                 lhs_type.TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   auto [opt_member, idx] = GetMemberInfo(lhs_valobj_sp, lhs_type, member_id,
@@ -3569,7 +3613,7 @@ DILASTNodeUP DILParser::BuildMemberOf(DILASTNodeUP lhs, std::string member_id,
             llvm::formatv("no member named '{0}' in {1}", member_id,
                           lhs_type.GetFullyUnqualifiedType().TypeDescription()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   MemberInfo member = opt_member.value();
@@ -3597,30 +3641,24 @@ DILASTNodeUP DILParser::BuildMemberOf(DILASTNodeUP lhs, std::string member_id,
 }
 
 void DILParser::Expect(Token::Kind kind) {
-  if (m_dil_token.IsNot(kind)) {
+  if (CurToken().IsNot(kind)) {
     BailOut(ErrorCode::kUnknown,
-            llvm::formatv("expected {0}, got: {1}", TokenKindsJoin(kind),
-                          TokenDescription(m_dil_token)),
-            m_dil_token.GetLocation());
+            llvm::formatv("expected {0}, got: {1}", kind, CurToken()),
+            CurToken().GetLocation());
   }
 }
 
-template <typename... Ts>
-    void DILParser::ExpectOneOf(Token::Kind k, Ts... ks) {
-  static_assert((std::is_same_v<Ts, Token::Kind> && ...),
-                "ExpectOneOf can be only called with values of type "
-                "Kind");
-
-  if (!m_dil_token.IsOneOf(k, ks...)) {
+void DILParser::ExpectOneOf(std::vector<Token::Kind> kinds_vec) {
+  if (!CurToken().IsOneOf(kinds_vec)) {
     BailOut(ErrorCode::kUnknown,
             llvm::formatv("expected any of ({0}), got: {1}",
-                          TokenKindsJoin(k, ks...), TokenDescription(m_dil_token)),
-            m_dil_token.GetLocation());
+                          llvm::iterator_range(kinds_vec), CurToken()),
+            CurToken().GetLocation());
   }
 }
 
-DILASTNodeUP DILParser::BuildIncrementDecrement(UnaryOpKind kind, DILASTNodeUP rhs,
-                                              uint32_t location) {
+ASTNodeUP DILParser::BuildIncrementDecrement(UnaryOpKind kind, ASTNodeUP rhs,
+                                             uint32_t location) {
   assert((kind == UnaryOpKind::PreInc || kind == UnaryOpKind::PreDec ||
           kind == UnaryOpKind::PostInc || kind == UnaryOpKind::PostDec) &&
          "illegal unary op kind, expected inc/dec");
@@ -3638,14 +3676,14 @@ DILASTNodeUP DILParser::BuildIncrementDecrement(UnaryOpKind kind, DILASTNodeUP r
   if (rhs->is_rvalue()) {
     BailOut(ErrorCode::kInvalidOperandType,
             llvm::formatv("expression is not assignable"), location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
   if (!rhs->is_context_var() && !AllowSideEffects()) {
     BailOut(ErrorCode::kInvalidOperandType,
             llvm::formatv("side effects are not supported in this context: "
                           "trying to modify data at the target process"),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
   llvm::StringRef op_name =
       (kind == UnaryOpKind::PreInc || kind == UnaryOpKind::PostInc)
@@ -3656,21 +3694,21 @@ DILASTNodeUP DILParser::BuildIncrementDecrement(UnaryOpKind kind, DILASTNodeUP r
             llvm::formatv("cannot {0} expression of enum type '{1}'", op_name,
                           rhs_type.GetTypeName()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
   if (!rhs_type.IsScalarType() && !rhs_type.IsPointerType()) {
     BailOut(ErrorCode::kInvalidOperandType,
             llvm::formatv("cannot {0} value of type '{1}'", op_name,
                           rhs_type.GetTypeName()),
             location);
-    return std::make_unique<ErrorNode>(bad_type);
+    return std::make_unique<ErrorNode>();
   }
 
   return std::make_unique<UnaryOpNode>(location, rhs->result_type(), kind,
                                        std::move(rhs));
 }
 
-CompilerType DILParser::PrepareBinaryAddition(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
+CompilerType DILParser::PrepareBinaryAddition(ASTNodeUP &lhs, ASTNodeUP &rhs,
                                               uint32_t location,
                                               bool is_comp_assign) {
   // Operation '+' works for:
@@ -3714,8 +3752,7 @@ CompilerType DILParser::PrepareBinaryAddition(DILASTNodeUP& lhs, DILASTNodeUP& r
   return ptr_type;
 }
 
-CompilerType DILParser::PrepareBinarySubtraction(DILASTNodeUP& lhs,
-                                                 DILASTNodeUP& rhs,
+CompilerType DILParser::PrepareBinarySubtraction(ASTNodeUP &lhs, ASTNodeUP &rhs,
                                                  uint32_t location,
                                                  bool is_comp_assign) {
   // Operation '-' works for:
@@ -3777,7 +3814,7 @@ CompilerType DILParser::PrepareBinarySubtraction(DILASTNodeUP& lhs,
   return bad_type;
 }
 
-CompilerType DILParser::PrepareBinaryMulDiv(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
+CompilerType DILParser::PrepareBinaryMulDiv(ASTNodeUP &lhs, ASTNodeUP &rhs,
                                             bool is_comp_assign) {
   // Operations {'*', '/'} work for:
   //
@@ -3797,7 +3834,7 @@ CompilerType DILParser::PrepareBinaryMulDiv(DILASTNodeUP& lhs, DILASTNodeUP& rhs
   return bad_type;
 }
 
-CompilerType DILParser::PrepareBinaryRemainder(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
+CompilerType DILParser::PrepareBinaryRemainder(ASTNodeUP &lhs, ASTNodeUP &rhs,
                                                bool is_comp_assign) {
   // Operation '%' works for:
   //
@@ -3816,7 +3853,7 @@ CompilerType DILParser::PrepareBinaryRemainder(DILASTNodeUP& lhs, DILASTNodeUP& 
   return bad_type;;
 }
 
-CompilerType DILParser::PrepareBinaryBitwise(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
+CompilerType DILParser::PrepareBinaryBitwise(ASTNodeUP &lhs, ASTNodeUP &rhs,
                                              bool is_comp_assign) {
   // Operations {'&', '|', '^'} work for:
   //
@@ -3836,7 +3873,7 @@ CompilerType DILParser::PrepareBinaryBitwise(DILASTNodeUP& lhs, DILASTNodeUP& rh
   return bad_type;;
 }
 
-CompilerType DILParser::PrepareBinaryShift(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
+CompilerType DILParser::PrepareBinaryShift(ASTNodeUP &lhs, ASTNodeUP &rhs,
                                            bool is_comp_assign) {
   // Operations {'<<', '>>'} work for:
   //
@@ -3860,10 +3897,8 @@ CompilerType DILParser::PrepareBinaryShift(DILASTNodeUP& lhs, DILASTNodeUP& rhs,
 }
 
 CompilerType DILParser::PrepareBinaryComparison(BinaryOpKind kind,
-                                                DILASTNodeUP& lhs,
-                                                DILASTNodeUP& rhs,
-                                                uint32_t location)
-{
+                                                ASTNodeUP &lhs, ASTNodeUP &rhs,
+                                                uint32_t location) {
   // Comparison works for:
   //
   //  {scalar,unscoped_enum} <-> {scalar,unscoped_enum}
@@ -3957,8 +3992,8 @@ CompilerType DILParser::PrepareBinaryComparison(BinaryOpKind kind,
   return bad_type;
 }
 
-CompilerType DILParser::PrepareBinaryLogical(const DILASTNodeUP& lhs,
-                                             const DILASTNodeUP& rhs) {
+CompilerType DILParser::PrepareBinaryLogical(const ASTNodeUP &lhs,
+                                             const ASTNodeUP &rhs) {
   CompilerType bad_type;
   auto lhs_type = lhs->GetDereferencedResultType();
   auto rhs_type = rhs->GetDereferencedResultType();
@@ -3983,10 +4018,9 @@ CompilerType DILParser::PrepareBinaryLogical(const DILASTNodeUP& lhs,
   return GetBasicType(m_ctx_scope, lldb::eBasicTypeBool);
 }
 
-CompilerType DILParser::PrepareCompositeAssignment(
-    CompilerType comp_assign_type,
-    const DILASTNodeUP& lhs,
-    uint32_t location) {
+CompilerType
+DILParser::PrepareCompositeAssignment(CompilerType comp_assign_type,
+                                      const ASTNodeUP &lhs, uint32_t location) {
   // In C++ the requirement here is that the expression is "assignable".
   // However in the debugger context side-effects are not allowed and the only
   // case where composite assignments are permitted is when modifying the
@@ -4034,7 +4068,8 @@ void DILParser::BailOut(ErrorCode code, const std::string& error,
 
   m_error = Status((uint32_t) code, lldb::eErrorTypeGeneric,
                    FormatDiagnostics(m_input_expr, error, loc));
-  m_dil_token = Token(Token::eof, "", 0);
+  // Advance the lexer token index to the end of the lexed tokens vector.
+  m_dil_lexer.ResetTokenIdx(m_dil_lexer.NumLexedTokens() - 1);
 }
 
 void DILParser::BailOut(Status error) {
@@ -4044,23 +4079,8 @@ void DILParser::BailOut(Status error) {
     return;
   }
   m_error = std::move(error);
-  m_dil_token = Token(Token::eof, "", 0);
-}
-
-void DILParser::ConsumeToken() {
-  if (m_dil_token.Is(Token::eof)) {
-    // Don't do anything if we're already at eof. This can happen if an error
-    // occurred during parsing and we're trying to bail out.
-    return;
-  }
-  m_dil_lexer.Advance();
-  m_dil_token = m_dil_lexer.GetCurrentToken();
-}
-
-std::string DILParser::TokenDescription(const Token& token) {
-  const auto& spelling = ((Token)token).GetSpelling();
-  llvm::StringRef kind_name = Token::GetTokenName(((Token)token).GetKind());;
-  return llvm::formatv("<'{0}' ({1})>", spelling, kind_name.str());
+  // Advance the lexer token index to the end of the lexed tokens vector.
+  m_dil_lexer.ResetTokenIdx(m_dil_lexer.NumLexedTokens() - 1);
 }
 
 bool DILParser::ImplicitConversionIsAllowed(CompilerType src, CompilerType dst,
@@ -4089,8 +4109,8 @@ bool DILParser::ImplicitConversionIsAllowed(CompilerType src, CompilerType dst,
   return false;
 }
 
-DILASTNodeUP DILParser::InsertImplicitConversion(DILASTNodeUP expr,
-                                                CompilerType type) {
+ASTNodeUP DILParser::InsertImplicitConversion(ASTNodeUP expr,
+                                              CompilerType type) {
   auto expr_type = expr->GetDereferencedResultType();
 
   // If the expression already has the required type, nothing to do here.
@@ -4121,9 +4141,8 @@ DILASTNodeUP DILParser::InsertImplicitConversion(DILASTNodeUP expr,
                         expr_type.TypeDescription(), type.TypeDescription()),
           expr->GetLocation());
   CompilerType bad_type;
-  return std::make_unique<ErrorNode>(bad_type);
+  return std::make_unique<ErrorNode>();
 }
-
 
 lldb::BasicType TypeDeclaration::GetBasicType() const {
   assert(m_is_builtin && "type declaration doesn't describe a builtin type");

--- a/lldb/test/API/commands/frame/var-dil/basics/AddressOf/TestFrameVarDILFullAddressOf.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/AddressOf/TestFrameVarDILFullAddressOf.py
@@ -19,42 +19,8 @@ class TestFrameVarDILAddressOf(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/AddressOf/TestFrameVarDILStrippedAddressOf.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/AddressOf/TestFrameVarDILStrippedAddressOf.py
@@ -19,42 +19,8 @@ class TestFrameVarDILAddressOf(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/BitField/TestFrameVarDILFullBitField.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitField/TestFrameVarDILFullBitField.py
@@ -19,42 +19,8 @@ class TestFrameVarDILBitField(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-       # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/BitField/TestFrameVarDILStrippedBitField.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitField/TestFrameVarDILStrippedBitField.py
@@ -19,42 +19,8 @@ class TestFrameVarDILBitField(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/BitwiseOperators/TestFrameVarDILFullBitwiseOperators.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitwiseOperators/TestFrameVarDILFullBitwiseOperators.py
@@ -19,42 +19,8 @@ class TestFrameVarDILBitwiseOperators(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/BitwiseOperators/TestFrameVarDILStrippedBitwiseOperators.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitwiseOperators/TestFrameVarDILStrippedBitwiseOperators.py
@@ -19,42 +19,8 @@ class TestFrameVarDILBitwiseOperators(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/GlobalVariableLookup/TestFrameVarDILFullGlobalVariableLookup.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/GlobalVariableLookup/TestFrameVarDILFullGlobalVariableLookup.py
@@ -19,42 +19,8 @@ class TestFrameVarDILGlobalVariableLookup(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/GlobalVariableLookup/TestFrameVarDILStrippedGlobalVariableLookup.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/GlobalVariableLookup/TestFrameVarDILStrippedGlobalVariableLookup.py
@@ -19,43 +19,8 @@ class TestFrameVarDILGlobalVariableLookup(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
-
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/Indirection/TestFrameVarDILFullIndirection.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/Indirection/TestFrameVarDILFullIndirection.py
@@ -19,42 +19,8 @@ class TestFrameVarDILIndirection(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/Indirection/TestFrameVarDILStrippedIndirection.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/Indirection/TestFrameVarDILStrippedIndirection.py
@@ -19,42 +19,8 @@ class TestFrameVarDILIndirection(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/InstanceVariables/TestFrameVarDILFullInstanceVariables.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/InstanceVariables/TestFrameVarDILFullInstanceVariables.py
@@ -19,42 +19,8 @@ class TestFrameVarDILInstanceVariables(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/InstanceVariables/TestFrameVarDILStrippedInstanceVariables.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/InstanceVariables/TestFrameVarDILStrippedInstanceVariables.py
@@ -19,42 +19,8 @@ class TestFrameVarDILInstanceVariables(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILFullLocalVars.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILFullLocalVars.py
@@ -19,42 +19,8 @@ class TestFrameVarDILLocalVars(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILStrippedLocalVars.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILStrippedLocalVars.py
@@ -19,42 +19,8 @@ class TestFrameVarDILLocalVars(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         # Test 'a' is 1
         self.expect("settings set target.experimental.use-DIL true",

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOf/TestFrameVarDILFullMemberOf.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOf/TestFrameVarDILFullMemberOf.py
@@ -19,42 +19,8 @@ class TestFrameVarDILMemberOf(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOf/TestFrameVarDILStrippedMemberOf.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOf/TestFrameVarDILStrippedMemberOf.py
@@ -19,42 +19,8 @@ class TestFrameVarDILMemberOf(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOfAnonymousMember/TestFrameVarDILFullMemberOfAnonymousMember.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOfAnonymousMember/TestFrameVarDILFullMemberOfAnonymousMember.py
@@ -19,42 +19,8 @@ class TestFrameVarDILMemberOfAnonymousMember(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOfAnonymousMember/TestFrameVarDILStrippedMemberOfAnonymousMember.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOfAnonymousMember/TestFrameVarDILStrippedMemberOfAnonymousMember.py
@@ -19,42 +19,8 @@ class TestFrameVarDILMemberOfAnonymousMember(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOfInheritance/TestFrameVarDILFullMemberOfInheritance.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOfInheritance/TestFrameVarDILFullMemberOfInheritance.py
@@ -19,42 +19,8 @@ class TestFrameVarDILMemberOfInheritance(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/MemberOfInheritance/TestFrameVarDILStrippedMemberOfInheritance.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/MemberOfInheritance/TestFrameVarDILStrippedMemberOfInheritance.py
@@ -19,42 +19,8 @@ class TestFrameVarDILMemberOfInheritance(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILFullQualifiedId.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILFullQualifiedId.py
@@ -19,42 +19,8 @@ class TestFrameVarDILQualifiedId(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILStrippedQualifiedId.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/QualifiedId/TestFrameVarDILStrippedQualifiedId.py
@@ -19,42 +19,8 @@ class TestFrameVarDILQualifiedId(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILFullSharedPtr.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILFullSharedPtr.py
@@ -19,42 +19,8 @@ class TestFrameVarDILSharedPtr(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILFullSharedPtrDeref.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILFullSharedPtrDeref.py
@@ -19,42 +19,8 @@ class TestFrameVarDILSharedPtrDeref(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILStrippedSharedPtr.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILStrippedSharedPtr.py
@@ -19,42 +19,8 @@ class TestFrameVarDILSharedPtr(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILStrippedSharedPtrDeref.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/SharedPtr/TestFrameVarDILStrippedSharedPtrDeref.py
@@ -19,44 +19,8 @@ class TestFrameVarDILSharedPtrDeref(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
-
-
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/Subscript/TestFrameVarDILFullSubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/Subscript/TestFrameVarDILFullSubscript.py
@@ -19,42 +19,8 @@ class TestFrameVarDILSubscript(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/Subscript/TestFrameVarDILStrippedSubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/Subscript/TestFrameVarDILStrippedSubscript.py
@@ -19,42 +19,8 @@ class TestFrameVarDILSubscript(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILFullUniquePtr.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILFullUniquePtr.py
@@ -19,42 +19,8 @@ class TestFrameVarDILUniquePtr(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILFullUniquePtrDeref.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILFullUniquePtrDeref.py
@@ -19,42 +19,8 @@ class TestFrameVarDILUniquePtrDeref(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILStrippedUniquePtr.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILStrippedUniquePtr.py
@@ -19,42 +19,8 @@ class TestFrameVarDILUniquePtr(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILStrippedUniquePtrDeref.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/UniquePtr/TestFrameVarDILStrippedUniquePtrDeref.py
@@ -19,42 +19,8 @@ class TestFrameVarDILUniquePtrDeref(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/casting/CastInheritedTypes/TestFrameVarDILFullCastInheritedTypes.py
+++ b/lldb/test/API/commands/frame/var-dil/casting/CastInheritedTypes/TestFrameVarDILFullCastInheritedTypes.py
@@ -19,42 +19,8 @@ class TestFrameVarDILArithmetic(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                    substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/math_exprs/Arithmetic/TestFrameVarDILFullArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/math_exprs/Arithmetic/TestFrameVarDILFullArithmetic.py
@@ -19,42 +19,8 @@ class TestFrameVarDILArithmetic(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/math_exprs/Assignment/TestFrameVarDILFullAssignment.py
+++ b/lldb/test/API/commands/frame/var-dil/math_exprs/Assignment/TestFrameVarDILFullAssignment.py
@@ -19,42 +19,8 @@ class TestFrameVarDILAssignment(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         self.expect("settings set target.experimental.use-DIL true",
                     substrs=[""])

--- a/lldb/test/API/commands/frame/var-dil/math_exprs/Assignment/TestFrameVarDILStrippedAssignment.py
+++ b/lldb/test/API/commands/frame/var-dil/math_exprs/Assignment/TestFrameVarDILStrippedAssignment.py
@@ -19,42 +19,8 @@ class TestFrameVarDILAssignment(TestBase):
 
     def test_frame_var(self):
         self.build()
-        self.do_test()
-
-    def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
-        command_result = lldb.SBCommandReturnObject()
-        interp = self.dbg.GetCommandInterpreter()
+        lldbutil.run_to_source_breakpoint(self, "Set a breakpoint here",
+                                          lldb.SBFileSpec("main.cpp"))
 
         #self.expect("settings set target.experimental.use-DIL true",
         #            substrs=[""])

--- a/lldb/unittests/DIL/DILLexerTests.cpp
+++ b/lldb/unittests/DIL/DILLexerTests.cpp
@@ -58,9 +58,9 @@ TEST(DILLexerTests, TokenKindTest) {
 
   EXPECT_TRUE(token.Is(Token::identifier));
   EXPECT_FALSE(token.Is(Token::l_paren));
-  EXPECT_TRUE(token.IsOneOf(Token::eof, Token::identifier));
-  EXPECT_FALSE(token.IsOneOf(Token::l_paren, Token::r_paren, Token::coloncolon,
-                             Token::eof));
+  EXPECT_TRUE(token.IsOneOf({Token::eof, Token::identifier}));
+  EXPECT_FALSE(token.IsOneOf(
+      {Token::l_paren, Token::r_paren, Token::coloncolon, Token::eof}));
 }
 
 TEST(DILLexerTests, LookAheadTest) {
@@ -143,7 +143,7 @@ TEST(DILLexerTests, IdentifiersTest) {
     DILLexer lexer(*maybe_lexer);
     Token token = lexer.GetCurrentToken();
     EXPECT_TRUE(token.IsNot(Token::identifier));
-    EXPECT_TRUE(token.IsOneOf(Token::eof, Token::coloncolon, Token::l_paren,
-                              Token::r_paren, Token::numeric_constant));
+    EXPECT_TRUE(token.IsOneOf({Token::eof, Token::coloncolon, Token::l_paren,
+                               Token::r_paren, Token::numeric_constant}));
   }
 }

--- a/lldb/unittests/DIL/DILTests.cpp
+++ b/lldb/unittests/DIL/DILTests.cpp
@@ -1164,9 +1164,9 @@ TEST_F(EvalTest, TestAddressOf) {
   EXPECT_THAT(Eval("&0.1"),
               IsError("cannot take the address of an rvalue of type 'double'"));
 
-  EXPECT_THAT(
-      Eval("&this"),
-      IsError("cannot take the address of an rvalue of type 'TestMethods *'"));
+  //EXPECT_THAT(
+  //    Eval("&this"),
+  //      IsError("cannot take the address of an rvalue of type 'TestMethods *'"));
   EXPECT_THAT(
       Eval("&(&s_str)"),
       IsError("cannot take the address of an rvalue of type 'const char **'"));
@@ -3512,7 +3512,7 @@ TEST_F(EvalTest, DISABLED_TestSeparateParsingWithContextVars) {
               IsError("use of undeclared identifier '$y'"));
 }
 
-TEST_F(EvalTest, DISABLED_TestRegisters) {
+TEST_F(EvalTest, TestRegisters) {
   // LLDB loses the value formatter when evaluating registers and prints their
   // value "as is". In lldb-eval the value formatter is preserved and the
   // register can be "pretty-printed" depending on its type (e.g. vector
@@ -3529,7 +3529,7 @@ TEST_F(EvalTest, DISABLED_TestRegisters) {
   EXPECT_THAT(Eval("(uint64_t) $flags"), IsOk());
 }
 
-TEST_F(EvalTest, TestRegistersNoDollar) {
+TEST_F(EvalTest, DISABLED_TestRegistersNoDollar) {
   this->compare_with_lldb_ = false;
 
   // lldb-eval also supports accessing registers without `$`. Any other

--- a/lldb/unittests/DIL/DILTests.cpp
+++ b/lldb/unittests/DIL/DILTests.cpp
@@ -1164,9 +1164,6 @@ TEST_F(EvalTest, TestAddressOf) {
   EXPECT_THAT(Eval("&0.1"),
               IsError("cannot take the address of an rvalue of type 'double'"));
 
-  //EXPECT_THAT(
-  //    Eval("&this"),
-  //      IsError("cannot take the address of an rvalue of type 'TestMethods *'"));
   EXPECT_THAT(
       Eval("&(&s_str)"),
       IsError("cannot take the address of an rvalue of type 'const char **'"));


### PR DESCRIPTION
 Major Changes:
    - Renamed DILASTNode to ASTNode.
    - Renamed DILInterpreter to Interpreter
    - Update Parser to have public static 'Parse' function that calls the private parser constructor then calls Run.
       Returns either an AST tree or an error.
    - Updated DILEval (and all the Visit funcitons) to return an
      LLVM::Expected<ValueObjectSP>.
    - Removed the m_error and m_result member variables from the Interpreter; just
      directly return the values or the errors.
    - Updated the calls to the parser & interpreter in DILGetValueForExpressionPath
      appropriately.
    - Moved the following class &   function declarations & defintions from DILAST
      to DILEval: struct MemberInfo, GetDynamicOrSyntheticValue, LookupIdentifier,
      LookupGlobalIdentifier, LookupStaticIdentifier, GetFieldWithNameIndexPath,
      GetMemberInfo, GetEnumMembers, ResolveTypeByName, DILFindVariable
    - Changed return type for all ASTNode::Accept() methods to
      LLVM::Expected<lldb::ValueObjectSP>.
    - Changed return type for all Visitor::Visit() methods to
      LLVM::Expected<lldb::ValueObjectSP>.
    - Removed unused Interpreter constructors.
    - Update Parser & Interpreter classes to directly use Stack Frame shared ptr
      for their context scope (passed into the constructors), for their
      execution context scopes.
    - Use llvm format providers rather than our own custom string formatters for
      Token::Kind , Token, TypeDeclaration::TypeSpecifier, and
      TypeDeclaration::SignSpecifier.
    - Remove m_dil_token from Parser class; use method 'CurToken()' in its place.
    - Remove ConsumeToken method (replace it with DILLexer::Advance()).
    - Make m_error in the Parser class a reference, which gets initialized from the
      static Parse method (ensuring a very limited lifetime scope for the error).
    - Modify SetUbStatus to return an error; modify callers to check & handle the
      error, and to have an LLVM::Expected<...> return type.
    - Check the error value after calls to ValueObject::Dereference.
    - Remove SetError from Interpreter; replace with direct setting & returning of
      errors.
    
    Minor Changes:
    - Simplify the set up in most of the Python tests.
    - Removed FromContextArg() & GetType() from IdentifierInfo
    - Remove all special handling for "this" (including kw_this).
    - Ran clang-format over all the changes => cleaned up the formatting.