### PR TITLE
Fix various nullptr errors

### DIFF
--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -2581,7 +2581,7 @@ DILASTNodeUP DILParser::BuildCStyleCast(CompilerType type, DILASTNodeUP rhs,
 
   } else if (type.IsNullPtrType()) {
     // Cast to nullptr type.
-    if (!type.IsNullPtrType() && !rhs->is_literal_zero()) {
+    if (!rhs_type.IsNullPtrType() && !rhs->is_literal_zero()) {
       BailOut(ErrorCode::kInvalidOperandType,
               llvm::formatv("C-style cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1181,6 +1181,8 @@ llvm::Expected<bool> ValueObject::GetValueAsBool() {
   }
   if (val_type.IsArrayType())
     return GetAddressOf() != 0;
+  if (val_type.IsNullPtrType())
+    return false;
 
   return llvm::make_error<llvm::StringError>("type cannot be converted to bool",
                                              llvm::inconvertibleErrorCode());
@@ -3685,7 +3687,7 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromNullptr(
   if (auto temp = type.GetByteSize(target.get()))
     byte_size = temp.value();
   lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
-      reinterpret_cast<const void *>(zero), byte_size, exe_ctx.GetByteOrder(),
+      reinterpret_cast<const void *>(&zero), byte_size, exe_ctx.GetByteOrder(),
       exe_ctx.GetAddressByteSize());
   return ValueObject::CreateValueObjectFromData(name, *data_sp, exe_ctx, type);
 }

--- a/lldb/unittests/DIL/DILTests.cpp
+++ b/lldb/unittests/DIL/DILTests.cpp
@@ -1432,20 +1432,21 @@ TEST_F(EvalTest, TestCStyleCastPointer) {
   EXPECT_THAT(Eval("(int&*)ap"), IsError("'type name' declared as a pointer "
                                          "to a reference of type 'int &'"));
 
-  GTEST_SKIP() << "Segfault when retrieving result value in the matcher";
-  EXPECT_THAT(Eval("(nullptr_t)nullptr"),
+  EXPECT_THAT(Eval("(std::__1::nullptr_t)nullptr"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
-  EXPECT_THAT(Eval("(nullptr_t)0"),
+  EXPECT_THAT(Eval("(std::__1::nullptr_t)0"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
 
-  EXPECT_THAT(Eval("(nullptr_t)1"),
-              IsError("C-style cast from 'int' to 'nullptr_t' (canonically "
-                      "referred to as 'std::nullptr_t')"
-                      " is not allowed"));
-  EXPECT_THAT(Eval("(nullptr_t)ap"),
-              IsError("C-style cast from 'int *' to 'nullptr_t' (canonically "
-                      "referred to as 'std::nullptr_t')"
-                      " is not allowed"));
+  EXPECT_THAT(
+      Eval("(nullptr_t)1"),
+      IsError("C-style cast from 'int' to 'std::__1::nullptr_t' (canonically "
+              "referred to as 'std::nullptr_t')"
+              " is not allowed"));
+  EXPECT_THAT(
+      Eval("(nullptr_t)ap"),
+      IsError("C-style cast from 'int *' to 'std::__1::nullptr_t' (canonically "
+              "referred to as 'std::nullptr_t')"
+              " is not allowed"));
 }
 
 TEST_F(EvalTest, TestCStyleCastNullptrType) {
@@ -1601,10 +1602,9 @@ TEST_F(EvalTest, TestCxxStaticCast) {
               IsError("two or more data types in declaration of 'type name'"));
 
   // Cast to nullptr.
-  GTEST_SKIP() << "Segfault when retrieving result value in the matcher";
-  EXPECT_THAT(Eval("static_cast<nullptr_t>(nullptr)"),
+  EXPECT_THAT(Eval("static_cast<std::__1::nullptr_t>(nullptr)"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
-  EXPECT_THAT(Eval("static_cast<nullptr_t>(0)"),
+  EXPECT_THAT(Eval("static_cast<std::__1::nullptr_t>(0)"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
 }
 
@@ -2587,7 +2587,8 @@ TEST_F(EvalTest, TestTernaryOperator) {
               IsEqual(Is32Bit() ? "0x0000000f" : "0x000000000000000f"));
   EXPECT_THAT(Eval("true ? nullptr : (int*)15"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
-
+  EXPECT_THAT(Eval("true ? 0 : nullptr"),
+              IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
   EXPECT_THAT(Eval("true ? nullptr : 0"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
 
@@ -2644,12 +2645,8 @@ TEST_F(EvalTest, TestTernaryOperator) {
 
   // Use pointers and arrays in bool context.
   EXPECT_THAT(Eval("pi ? 1 : 2"), IsEqual("1"));
-  EXPECT_THAT(Eval("arr2 ? 1 : 2"), IsEqual("1"));
-
-  GTEST_SKIP() << "Segfault when retrieving result value in the matcher";
-  EXPECT_THAT(Eval("true ? 0 : nullptr"),
-              IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
   EXPECT_THAT(Eval("nullptr ? 1 : 2"), IsEqual("2"));
+  EXPECT_THAT(Eval("arr2 ? 1 : 2"), IsEqual("1"));
 }
 
 TEST_F(EvalTest, TestSizeOf) {


### PR DESCRIPTION
Fixed:
* Wrong operand type check in `BuildCStyleCast`
* Missing conversion from nullptr to bool in `GetValueAsBool`
* Passing value instead of value address in `CreateValueObjectFromNullptr`
