### PR TITLE
[Eval] Use user compiler type for arithmetic operations

### DIFF
--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -1812,7 +1812,7 @@ Interpreter::EvaluateBinaryAddition(lldb::ValueObjectSP lhs,
     assert(lhs->GetCompilerType().CompareTypes(rhs->GetCompilerType()) &&
            "invalid ast: operand must have the same type");
     return EvaluateArithmeticOp(m_target, BinaryOpKind::Add, lhs, rhs,
-                                lhs->GetCompilerType().GetCanonicalType());
+                                lhs->GetCompilerType());
   }
 
   // Here one of the operands must be a pointer and the other one an integer.
@@ -1847,7 +1847,7 @@ Interpreter::EvaluateBinarySubtraction(lldb::ValueObjectSP lhs,
     assert(lhs->GetCompilerType().CompareTypes(rhs->GetCompilerType()) &&
            "invalid ast: operand must have the same type");
     return EvaluateArithmeticOp(m_target, BinaryOpKind::Sub, lhs, rhs,
-                                lhs->GetCompilerType().GetCanonicalType());
+                                lhs->GetCompilerType());
   }
   assert(lhs->GetCompilerType().IsPointerType()
          && "invalid ast: lhs must be a pointer");
@@ -1907,7 +1907,7 @@ Interpreter::EvaluateBinaryMultiplication(lldb::ValueObjectSP lhs,
          "invalid ast: operands must be arithmetic and have the same type");
 
   return EvaluateArithmeticOp(m_target, BinaryOpKind::Mul, lhs, rhs,
-                              lhs->GetCompilerType().GetCanonicalType());
+                              lhs->GetCompilerType());
 }
 
 llvm::Expected<lldb::ValueObjectSP>
@@ -1934,7 +1934,7 @@ Interpreter::EvaluateBinaryDivision(lldb::ValueObjectSP lhs,
   }
 
   return EvaluateArithmeticOp(m_target, BinaryOpKind::Div, lhs, rhs,
-                              lhs->GetCompilerType().GetCanonicalType());
+                              lhs->GetCompilerType());
 }
 
 llvm::Expected<lldb::ValueObjectSP>
@@ -1973,7 +1973,7 @@ Interpreter::EvaluateBinaryBitwise(BinaryOpKind kind, lldb::ValueObjectSP lhs,
          "invalid ast: operation must be '&', '|' or '^'");
 
   return EvaluateArithmeticOpInteger(m_target, kind, lhs, rhs,
-                                     lhs->GetCompilerType().GetCanonicalType());
+                                     lhs->GetCompilerType());
 }
 
 llvm::Expected<lldb::ValueObjectSP>

--- a/lldb/unittests/DIL/DILTests.cpp
+++ b/lldb/unittests/DIL/DILTests.cpp
@@ -669,7 +669,7 @@ TEST_F(EvalTest, TestBitwiseOperators) {
   EXPECT_THAT(Eval("(signed char)-123 >> 8"), IsEqual("-1"));
 
   EXPECT_THAT(Eval("0b1011 & 0xFF"), IsEqual("11"));
-  EXPECT_THAT(Eval("0b1011 & mask_ff"), XFail(IsEqual("11")));
+  EXPECT_THAT(Eval("0b1011 & mask_ff"), IsEqual("11"));
   EXPECT_THAT(Eval("0b1011 & 0b0111"), IsEqual("3"));
   EXPECT_THAT(Eval("0b1011 | 0b0111"), IsEqual("15"));
   EXPECT_THAT(Eval("-0b1011 | 0xFF"), IsEqual("-1"));
@@ -2237,7 +2237,7 @@ TEST_F(EvalTest, TestBitFieldPromotion) {
   EXPECT_THAT(Eval("bf.f - 2"), IsEqual("4294967295"));
   EXPECT_THAT(Eval("bf.g - 2"), IsEqual("-1"));
   EXPECT_THAT(Eval("bf.h - 2"), IsEqual("-1"));
-  EXPECT_THAT(Eval("bf.i - 2"), XFail(IsEqual("18446744073709551615")));
+  EXPECT_THAT(Eval("bf.i - 2"), IsEqual("18446744073709551615"));
   EXPECT_THAT(Eval("bf.g - bf.b"), IsEqual("-8"));
 
   EXPECT_THAT(Eval("-(true ? bf.b : bf.a)"), IsEqual("-9"));
@@ -2247,7 +2247,7 @@ TEST_F(EvalTest, TestBitFieldPromotion) {
   EXPECT_THAT(Eval("-(true ? bf.b : bf.h)"), IsEqual("-9"));
 
   if (HAS_METHOD(lldb::SBType, GetEnumerationIntegerType())) {
-    EXPECT_THAT(Eval("bf.j - 2"), XFail(IsEqual("4294967295")));
+    EXPECT_THAT(Eval("bf.j - 2"), IsEqual("4294967295"));
     EXPECT_THAT(Eval("-(true ? bf.b : bf.j)"), IsEqual("4294967287"));
     EXPECT_THAT(Eval("-(true ? bf.e : bf.j)"), IsEqual("4294967295"));
   }


### PR DESCRIPTION
Using only the canonical type for arithmetic expressions is unnecessary. lldb doesn't discard the user type for the same expressions.