### PR TITLE
Update code to made upstream local variables PR.

### DIFF
--- a/lldb/include/lldb/ValueObject/DILAST.h
+++ b/lldb/include/lldb/ValueObject/DILAST.h
@@ -18,6 +18,8 @@
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Error.h"
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -280,12 +282,11 @@ private:
 class IdentifierNode : public ASTNode {
 public:
   IdentifierNode(uint32_t location, std::string name,
-                 lldb::DynamicValueType use_dynamic,
                  std::unique_ptr<IdentifierInfo> identifier, bool is_rvalue,
                  bool is_context_var)
       : ASTNode(location, NodeKind::eIdentifierNode), m_is_rvalue(is_rvalue),
         m_is_context_var(is_context_var), m_name(std::move(name)),
-        m_identifier(std::move(identifier)), m_use_dynamic(use_dynamic) {}
+        m_identifier(std::move(identifier)) {}
 
   llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
   bool is_rvalue() const override { return m_is_rvalue; }
@@ -297,7 +298,6 @@ public:
     return m_identifier->GetValue().get();
   }
 
-  lldb::DynamicValueType GetUseDynamic() const { return m_use_dynamic; }
   std::string GetName() const { return m_name; }
   const IdentifierInfo &info() const { return *m_identifier; }
 
@@ -310,7 +310,6 @@ private:
   bool m_is_context_var;
   std::string m_name;
   std::unique_ptr<IdentifierInfo> m_identifier;
-  lldb::DynamicValueType m_use_dynamic;
 };
 
 class SizeOfNode : public ASTNode {

--- a/lldb/include/lldb/ValueObject/DILEval.h
+++ b/lldb/include/lldb/ValueObject/DILEval.h
@@ -11,6 +11,8 @@
 
 #include "lldb/ValueObject/DILAST.h"
 #include "lldb/ValueObject/DILParser.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 #include <memory>
 #include <vector>
 
@@ -54,15 +56,14 @@ public:
               lldb::DynamicValueType use_dynamic,
               std::shared_ptr<StackFrame> frame_sp);
 
-  llvm::Expected<lldb::ValueObjectSP> DILEval(const ASTNode *tree,
-                                              lldb::TargetSP target_sp);
+  llvm::Expected<lldb::ValueObjectSP> Evaluate(const ASTNode *tree);
 
   void SetContextVars(
       std::unordered_map<std::string, lldb::ValueObjectSP> context_vars);
 
  protected:
-   llvm::Expected<lldb::ValueObjectSP>
-   DILEvalNode(const ASTNode *node, FlowAnalysis *flow = nullptr);
+   llvm::Expected<lldb::ValueObjectSP> EvalNode(const ASTNode *node,
+                                                FlowAnalysis *flow = nullptr);
 
    lldb::ValueObjectSP EvaluateMemberOf(lldb::ValueObjectSP value,
                                         const std::vector<uint32_t> &path,

--- a/lldb/include/lldb/ValueObject/DILParser.h
+++ b/lldb/include/lldb/ValueObject/DILParser.h
@@ -10,13 +10,16 @@
 #define LLDB_VALUEOBJECT_DILPARSER_H
 
 #include "lldb/Target/ExecutionContextScope.h"
+#include "lldb/Utility/DiagnosticsRendering.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/ValueObject/DILAST.h"
 #include "lldb/ValueObject/DILLexer.h"
 #include "lldb/ValueObject/DILLiteralParsers.h"
+#include "llvm/Support/Error.h"
 #include <memory>
 #include <optional>
 #include <string>
+#include <system_error>
 #include <tuple>
 #include <vector>
 
@@ -69,8 +72,30 @@ enum class ErrorCode : unsigned char {
   kUnknown,
 };
 
-std::string FormatDiagnostics(llvm::StringRef input_expr,
-                              const std::string &message, uint32_t loc);
+// The following is modeled on class OptionParseError.
+class DILDiagnosticError
+    : public llvm::ErrorInfo<DILDiagnosticError, DiagnosticError> {
+  DiagnosticDetail m_detail;
+
+public:
+  using llvm::ErrorInfo<DILDiagnosticError, DiagnosticError>::ErrorInfo;
+  DILDiagnosticError(DiagnosticDetail detail)
+      : ErrorInfo(make_error_code(std::errc::invalid_argument)),
+        m_detail(std::move(detail)) {}
+
+  DILDiagnosticError(llvm::StringRef expr, const std::string &message,
+                     uint32_t loc, uint16_t err_len);
+
+  std::unique_ptr<CloneableError> Clone() const override {
+    return std::make_unique<DILDiagnosticError>(m_detail);
+  }
+
+  llvm::ArrayRef<DiagnosticDetail> GetDetails() const override {
+    return {m_detail};
+  }
+
+  std::string message() const override { return m_detail.rendered; }
+};
 
 Status SetUbStatus(ErrorCode code);
 
@@ -170,9 +195,9 @@ class DILParser {
                       std::shared_ptr<StackFrame> frame_sp,
                       lldb::DynamicValueType use_dynamic, bool use_synthetic,
                       bool fragile_ivar, bool check_ptr_vs_member,
-                      Status &error);
+                      llvm::Error &error);
 
-   llvm::Expected<ASTNodeUP> Run();
+   ASTNodeUP Run();
 
    ASTNodeUP ParseExpression();
    ASTNodeUP ParseAssignmentExpression();
@@ -227,9 +252,7 @@ class DILParser {
                                     bool is_src_literal_zero = false);
    ASTNodeUP InsertImplicitConversion(ASTNodeUP expr, CompilerType type);
 
-   void BailOut(ErrorCode error_code, const std::string &error, uint32_t loc);
-
-   void BailOut(Status error);
+   void BailOut(const std::string &error, uint32_t loc, uint16_t err_len);
 
    void Expect(Token::Kind kind);
 
@@ -297,7 +320,8 @@ class DILParser {
    }
 
   void TentativeParsingRollback(uint32_t saved_idx) {
-    m_error.Clear();
+    if (m_error)
+      llvm::consumeError(std::move(m_error));
     m_dil_lexer.ResetTokenIdx(saved_idx);
   }
 
@@ -312,7 +336,7 @@ class DILParser {
 
   DILLexer m_dil_lexer;
   // Holds an error if it occures during parsing.
-  Status &m_error;
+  llvm::Error &m_error;
 
   bool m_allow_side_effects = true;
 

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -558,7 +558,7 @@ ValueObjectSP StackFrame::DILGetValueForVariableExpressionPath(
   dil::Interpreter interpreter(target, var_expr, use_dynamic,
                                shared_from_this());
 
-  auto valobj_or_error = interpreter.DILEval((*tree_or_error).get(), target);
+  auto valobj_or_error = interpreter.Evaluate((*tree_or_error).get());
   if (!valobj_or_error) {
     error = Status::FromError(valobj_or_error.takeError());
     return ValueObjectSP();

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -577,17 +577,13 @@ void Interpreter::SetContextVars(
   m_context_vars = std::move(context_vars);
 }
 
-llvm::Expected<lldb::ValueObjectSP>
-Interpreter::DILEval(const ASTNode *tree, lldb::TargetSP target_sp) {
-  // Evaluate an AST.
-  auto value_or_error = DILEvalNode(tree);
-
-  // Return the computed result-or-error.
-  return value_or_error;
+llvm::Expected<lldb::ValueObjectSP> Interpreter::Evaluate(const ASTNode *tree) {
+  // Traverse and evaluate an AST.
+  return EvalNode(tree);
 }
 
-llvm::Expected<lldb::ValueObjectSP>
-Interpreter::DILEvalNode(const ASTNode *node, FlowAnalysis *flow) {
+llvm::Expected<lldb::ValueObjectSP> Interpreter::EvalNode(const ASTNode *node,
+                                                          FlowAnalysis *flow) {
   // Set up the evaluation context for the current node.
   m_flow_analysis_chain.push_back(flow);
   // Traverse an AST pointed by the `node`.
@@ -685,7 +681,7 @@ Interpreter::Visit(const StringLiteralNode *node) {
 
 llvm::Expected<lldb::ValueObjectSP>
 Interpreter::Visit(const IdentifierNode *node) {
-  lldb::DynamicValueType use_dynamic = node->GetUseDynamic();
+  lldb::DynamicValueType use_dynamic = m_default_dynamic;
 
   std::unique_ptr<IdentifierInfo> identifier =
       LookupIdentifier(node->GetName(), m_exe_ctx_scope, use_dynamic);
@@ -697,10 +693,8 @@ Interpreter::Visit(const IdentifierNode *node) {
   if (!identifier) {
     std::string errMsg =
         llvm::formatv("use of undeclared identifier '{0}'", node->GetName());
-    Status error = Status(
-        (uint32_t)ErrorCode::kUndeclaredIdentifier, lldb::eErrorTypeGeneric,
-        FormatDiagnostics(m_expr, errMsg, node->GetLocation()));
-    return error.ToError();
+    return llvm::make_error<DILDiagnosticError>(
+        m_expr, errMsg, node->GetLocation(), node->GetName().size());
   }
 
   lldb::ValueObjectSP val;
@@ -715,29 +709,22 @@ Interpreter::Visit(const IdentifierNode *node) {
       assert(node->is_context_var() && "invalid ast: context var expected");
       val = ResolveContextVar(node->GetName());
       if (!val) {
-        Status error = Status(
-            (uint32_t)ErrorCode::kUndeclaredIdentifier, lldb::eErrorTypeGeneric,
-            FormatDiagnostics(
-                m_expr,
-                llvm::formatv("use of undeclared identifier '{0}'",
-                              node->GetName()),
-                node->GetLocation()));
-        return error.ToError();
+        return llvm::make_error<DILDiagnosticError>(
+            m_expr,
+            llvm::formatv("use of undeclared identifier '{0}'",
+                          node->GetName()),
+            node->GetLocation(), node->GetName().size());
       }
       if (!node->GetDereferencedResultType().CompareTypes(
               val->GetCompilerType())) {
-        Status error = Status(
-            (uint32_t)ErrorCode::kInvalidOperandType, lldb::eErrorTypeGeneric,
-            FormatDiagnostics(
-                m_expr,
-                llvm::formatv(
-                    "unexpected type of context variable"
-                    " '{0}' (expected {1}, got {2})",
-                    node->GetName(),
-                    node->GetDereferencedResultType().TypeDescription(),
-                    val->GetCompilerType().TypeDescription()),
-                node->GetLocation()));
-        return error.ToError();
+        return llvm::make_error<DILDiagnosticError>(
+            m_expr,
+            llvm::formatv("unexpected type of context variable"
+                          " '{0}' (expected {1}, got {2})",
+                          node->GetName(),
+                          node->GetDereferencedResultType().TypeDescription(),
+                          val->GetCompilerType().TypeDescription()),
+            node->GetLocation(), node->GetName().size());
       }
       break;
 
@@ -748,13 +735,6 @@ Interpreter::Visit(const IdentifierNode *node) {
     default:
       assert(false && "invalid ast: invalid identifier kind");
     }
-
-  if (val->GetCompilerType().IsReferenceType()) {
-    Status error;
-    val = val->Dereference(error);
-    if (error.Fail())
-      return error.ToError();
-  }
 
   return val;
 }
@@ -791,7 +771,7 @@ Interpreter::Visit(const BuiltinFunctionCallNode *node) {
            "invalid ast: expected exactly one argument to `__log2`");
     // Get the first (and the only) argument and evaluate it.
     auto &arg = node->arguments()[0];
-    auto val_or_err = DILEvalNode(arg.get());
+    auto val_or_err = EvalNode(arg.get());
     if (!val_or_err) {
       return val_or_err;
     }
@@ -826,7 +806,7 @@ Interpreter::Visit(const BuiltinFunctionCallNode *node) {
            "invalid ast: expected exactly two arguments to `__findnonnull`");
 
     auto &arg1 = node->arguments()[0];
-    auto val_or_err = DILEvalNode(arg1.get());
+    auto val_or_err = EvalNode(arg1.get());
     if (!val_or_err) {
       return val_or_err;
     }
@@ -840,19 +820,16 @@ Interpreter::Visit(const BuiltinFunctionCallNode *node) {
     } else if (val1_sp->GetCompilerType().IsArrayType()) {
       addr = val1_sp->GetLoadAddress();
     } else {
-      Status error = Status(
-          (uint32_t)ErrorCode::kInvalidOperandType, lldb::eErrorTypeGeneric,
-          FormatDiagnostics(
-              m_expr,
-              llvm::formatv("no known conversion from '{0}' to 'T*' for 1st "
-                            "argument of __findnonnull()",
-                            val1_sp->GetCompilerType().GetTypeName()),
-              arg1->GetLocation()));
-      return error.ToError();
+      return llvm::make_error<DILDiagnosticError>(
+          m_expr,
+          llvm::formatv("no known conversion from '{0}' to 'T*' for 1st "
+                        "argument of __findnonnull()",
+                        val1_sp->GetCompilerType().GetTypeName()),
+          arg1->GetLocation(), 2);
     }
 
     auto &arg2 = node->arguments()[1];
-    auto val2_or_err = DILEvalNode(arg2.get());
+    auto val2_or_err = EvalNode(arg2.get());
     if (!val2_or_err) {
       return val2_or_err;
     }
@@ -860,16 +837,13 @@ Interpreter::Visit(const BuiltinFunctionCallNode *node) {
     int64_t size = val2_sp->GetValueAsSigned(0);
 
     if (size < 0 || size > 100000000) {
-      Status error = Status(
-          (uint32_t)ErrorCode::kInvalidOperandType, lldb::eErrorTypeGeneric,
-          FormatDiagnostics(
-              m_expr,
-              llvm::formatv(
-                  "passing in a buffer size ('{0}') that is negative or in "
-                  "excess of 100 million to __findnonnull() is not allowed.",
-                  size),
-              arg2->GetLocation()));
-      return error.ToError();
+      return llvm::make_error<DILDiagnosticError>(
+          m_expr,
+          llvm::formatv(
+              "passing in a buffer size ('{0}') that is negative or in "
+              "excess of 100 million to __findnonnull() is not allowed.",
+              size),
+          arg2->GetLocation(), 2);
     }
 
     lldb::ProcessSP process = m_target->GetProcessSP();
@@ -895,15 +869,12 @@ Interpreter::Visit(const BuiltinFunctionCallNode *node) {
           process->ReadMemory(addr + i * ptr_size, &memory, ptr_size, error);
 
       if (error.Fail() || read != ptr_size) {
-        Status error =
-            Status((uint32_t)ErrorCode::kUnknown, lldb::eErrorTypeGeneric,
-                   FormatDiagnostics(
-                       m_expr,
-                       llvm::formatv("error calling __findnonnull(): {0}",
-                                     error.AsCString() ? error.AsCString()
-                                                       : "cannot read memory"),
-                       node->GetLocation()));
-        return error.ToError();
+        return llvm::make_error<DILDiagnosticError>(
+            m_expr,
+            llvm::formatv("error calling __findnonnull(): {0}",
+                          error.AsCString() ? error.AsCString()
+                                            : "cannot read memory"),
+            node->GetLocation(), node->name().size());
       }
 
       if (memory != 0) {
@@ -932,7 +903,7 @@ llvm::Expected<lldb::ValueObjectSP>
 Interpreter::Visit(const CStyleCastNode *node) {
   // Get the type and the value we need to cast.
   auto type = node->type();
-  auto rhs_or_err = DILEvalNode(node->operand());
+  auto rhs_or_err = EvalNode(node->operand());
   if (!rhs_or_err) {
     return rhs_or_err;
   }
@@ -1021,7 +992,7 @@ llvm::Expected<lldb::ValueObjectSP>
 Interpreter::Visit(const CxxStaticCastNode *node) {
   // Get the type and the value we need to cast.
   auto type = node->type();
-  auto rhs_or_err = DILEvalNode(node->operand());
+  auto rhs_or_err = EvalNode(node->operand());
   if (!rhs_or_err) {
     return rhs_or_err;
   }
@@ -1119,7 +1090,7 @@ llvm::Expected<lldb::ValueObjectSP>
 Interpreter::Visit(const CxxReinterpretCastNode *node) {
   // Get the type and the value we need to cast.
   auto type = node->type();
-  auto rhs_or_err = DILEvalNode(node->operand());
+  auto rhs_or_err = EvalNode(node->operand());
   if (!rhs_or_err) {
     return rhs_or_err;
   }
@@ -1197,7 +1168,7 @@ Interpreter::Visit(const MemberOfNode *node) {
   // for members from non-virtual bases.
 
   Status error;
-  auto base_or_err = DILEvalNode(node->base());
+  auto base_or_err = EvalNode(node->base());
   if (!base_or_err) {
     return base_or_err;
   }
@@ -1224,12 +1195,12 @@ Interpreter::Visit(const MemberOfNode *node) {
 
 llvm::Expected<lldb::ValueObjectSP>
 Interpreter::Visit(const ArraySubscriptNode *node) {
-  auto base_or_err = DILEvalNode(node->base());
+  auto base_or_err = EvalNode(node->base());
   if (!base_or_err) {
     return base_or_err;
   }
   lldb::ValueObjectSP base = *base_or_err;
-  auto index_or_err = DILEvalNode(node->index());
+  auto index_or_err = EvalNode(node->index());
   if (!index_or_err) {
     return index_or_err;
   }
@@ -1271,16 +1242,13 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
   if (synthetic) {
     uint32_t num_children = synthetic->GetNumChildrenIgnoringErrors();
     if (index->GetValueAsSigned(0) >= num_children) {
-      Status error = Status(
-          (uint32_t)ErrorCode::kSubscriptOutOfRange, lldb::eErrorTypeGeneric,
-          FormatDiagnostics(
-              m_expr,
-              llvm::formatv("array index {0} is not valid for \"({1}) {2}\"",
-                            index->GetValueAsSigned(0),
-                            base->GetTypeName().AsCString("<invalid type>"),
-                            base->GetName().AsCString()),
-              node->GetLocation()));
-      return error.ToError();
+      return llvm::make_error<DILDiagnosticError>(
+          m_expr,
+          llvm::formatv("array index {0} is not valid for \"({1}) {2}\"",
+                        index->GetValueAsSigned(0),
+                        base->GetTypeName().AsCString("<invalid type>"),
+                        base->GetName().AsCString()),
+          node->GetLocation(), 3);
     }
   }
 
@@ -1321,7 +1289,7 @@ Interpreter::Visit(const BinaryOpNode *node) {
   // Short-circuit logical operators.
   if (node->kind() == BinaryOpKind::LAnd || node->kind() == BinaryOpKind::LOr) {
     Status error;
-    auto lhs_or_err = DILEvalNode(node->lhs());
+    auto lhs_or_err = EvalNode(node->lhs());
     if (!lhs_or_err) {
       return lhs_or_err;
     }
@@ -1349,7 +1317,7 @@ Interpreter::Visit(const BinaryOpNode *node) {
     }
 
     // Breaking early didn't happen, evaluate the RHS and use it as a result.
-    auto rhs_or_err = DILEvalNode(node->rhs());
+    auto rhs_or_err = EvalNode(node->rhs());
     if (!rhs_or_err) {
       return rhs_or_err;
     }
@@ -1371,12 +1339,12 @@ Interpreter::Visit(const BinaryOpNode *node) {
   }
 
   // All other binary operations require evaluating both operands.
-  auto lhs_or_err = DILEvalNode(node->lhs());
+  auto lhs_or_err = EvalNode(node->lhs());
   if (!lhs_or_err) {
     return lhs_or_err;
   }
   lldb::ValueObjectSP lhs = *lhs_or_err;
-  auto rhs_or_err = DILEvalNode(node->rhs());
+  auto rhs_or_err = EvalNode(node->rhs());
   if (!rhs_or_err) {
     return rhs_or_err;
   }
@@ -1469,7 +1437,7 @@ Interpreter::Visit(const UnaryOpNode *node) {
       /* address_of_is_pending */ node->kind() == UnaryOpKind::AddrOf);
 
   Status error;
-  auto rhs_or_err = DILEvalNode(node->rhs(), &rhs_flow);
+  auto rhs_or_err = EvalNode(node->rhs(), &rhs_flow);
   if (!rhs_or_err) {
     return rhs_or_err;
   }
@@ -1546,7 +1514,7 @@ Interpreter::Visit(const UnaryOpNode *node) {
 
 llvm::Expected<lldb::ValueObjectSP>
 Interpreter::Visit(const TernaryOpNode *node) {
-  auto cond_or_err = DILEvalNode(node->cond());
+  auto cond_or_err = EvalNode(node->cond());
   if (!cond_or_err) {
     return cond_or_err;
   }
@@ -1560,9 +1528,9 @@ Interpreter::Visit(const TernaryOpNode *node) {
   auto value_or_err = cond->GetValueAsBool();
   if (value_or_err) {
     if (*value_or_err)
-      return DILEvalNode(node->lhs(), flow_analysis());
+      return EvalNode(node->lhs(), flow_analysis());
 
-    return DILEvalNode(node->rhs(), flow_analysis());
+    return EvalNode(node->rhs(), flow_analysis());
   }
   return value_or_err.takeError();
 }

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -13,6 +13,7 @@
 
 #include "lldb/ValueObject/DILParser.h"
 #include "lldb/Target/ExecutionContextScope.h"
+#include "lldb/Utility/DiagnosticsRendering.h"
 #include "lldb/ValueObject/DILAST.h"
 #include "lldb/ValueObject/DILEval.h"
 #include "lldb/lldb-enumerations.h"
@@ -751,16 +752,21 @@ GetMemberInfo(lldb::ValueObjectSP lhs_val_sp, CompilerType type,
   return {member, std::move(idx)};
 }
 
-std::string FormatDiagnostics(llvm::StringRef text, const std::string &message,
-                              uint32_t loc) {
-  // Get the position, in the current line of text, of the diagnostics pointer.
-  // ('loc' is the location of the start of the current token/error within the
-  // overall text line).
-  int32_t arrow = loc + 1; // Column offset starts at 1, not 0.
-
-  return llvm::formatv("<expr:1:{0}>: {1}\n{2}\n{3}", loc + 1, message,
-                       llvm::fmt_pad(text, 0, 0),
-                       llvm::fmt_pad("^", arrow - 1, 0));
+DILDiagnosticError::DILDiagnosticError(llvm::StringRef expr,
+                                       const std::string &message, uint32_t loc,
+                                       uint16_t err_len)
+    : ErrorInfo(make_error_code(std::errc::invalid_argument)) {
+  DiagnosticDetail::SourceLocation sloc = {
+      FileSpec{}, /*line=*/1, static_cast<uint16_t>(loc + 1),
+      err_len,    false,      /*in_user_input=*/true};
+  std::string spaces(loc, ' ');
+  std::string rendered_msg =
+      llvm::formatv("<user expression 0>:1:{0}: {1}\n   1 | {2}\n     | {3}^",
+                    loc + 1, message, expr, spaces);
+  m_detail.source_location = sloc;
+  m_detail.severity = lldb::eSeverityError;
+  m_detail.message = message;
+  m_detail.rendered = std::move(rendered_msg);
 }
 
 llvm::Expected<ASTNodeUP>
@@ -768,22 +774,29 @@ DILParser::Parse(llvm::StringRef dil_input_expr, DILLexer lexer,
                  std::shared_ptr<StackFrame> frame_sp,
                  lldb::DynamicValueType use_dynamic, bool use_synthetic,
                  bool fragile_ivar, bool check_ptr_vs_member) {
-  Status error;
+  llvm::Error error = llvm::Error::success();
   DILParser parser(dil_input_expr, lexer, frame_sp, use_dynamic, use_synthetic,
                    fragile_ivar, check_ptr_vs_member, error);
-  return parser.Run();
+
+  ASTNodeUP node_up = parser.Run();
+
+  if (error)
+    return error;
+
+  return node_up;
 }
 
 DILParser::DILParser(llvm::StringRef dil_input_expr, DILLexer lexer,
                      std::shared_ptr<StackFrame> frame_sp,
                      lldb::DynamicValueType use_dynamic, bool use_synthetic,
-                     bool fragile_ivar, bool check_ptr_vs_member, Status &error)
-    : m_ctx_scope(frame_sp), m_input_expr(dil_input_expr), m_dil_lexer(lexer),
-      m_error(error), m_use_dynamic(use_dynamic),
+                     bool fragile_ivar, bool check_ptr_vs_member,
+                     llvm::Error &error)
+    : m_ctx_scope(frame_sp), m_input_expr(dil_input_expr),
+      m_dil_lexer(std::move(lexer)), m_error(error), m_use_dynamic(use_dynamic),
       m_use_synthetic(use_synthetic), m_fragile_ivar(fragile_ivar),
       m_check_ptr_vs_member(check_ptr_vs_member) {}
 
-llvm::Expected<ASTNodeUP> DILParser::Run() {
+ASTNodeUP DILParser::Run() {
   ASTNodeUP expr;
 
   if (m_dil_lexer.IsStringLiteral(CurToken().GetKind()) &&
@@ -795,10 +808,6 @@ llvm::Expected<ASTNodeUP> DILParser::Run() {
   }
 
   Expect(Token::eof);
-
-  // Check for any parsing errors.
-  if (m_error.Fail())
-    return m_error.ToError();
 
   return expr;
 }
@@ -812,11 +821,10 @@ CompilerType DILParser::ResolveTypeDeclarators(
     if (tk == Token::star) {
       // Pointers to reference types are forbidden.
       if (type.IsReferenceType()) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv("'type name' declared as a pointer to a "
+        BailOut(llvm::formatv("'type name' declared as a pointer to a "
                               "reference of type {0}",
                               type.TypeDescription()),
-                loc);
+                loc, type.TypeDescription().length());
         return bad_type;
       }
       // Get pointer type for the base type: e.g. int* -> int**.
@@ -825,8 +833,8 @@ CompilerType DILParser::ResolveTypeDeclarators(
     } else if (tk == Token::amp) {
       // References to references are forbidden.
       if (type.IsReferenceType()) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                "type name declared as a reference to a reference", loc);
+        BailOut("type name declared as a reference to a reference", loc,
+                type.TypeDescription().length());
         return bad_type;
       }
       // Get reference type for the base type: e.g. int -> int&.
@@ -866,9 +874,8 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       // "int" can have signedness and be combined with "short", "long" and
       // "long long" (but not with another "int").
       if (type_decl->m_has_int_specifier) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                "cannot combine with previous 'int' declaration specifier",
-                loc);
+        BailOut("cannot combine with previous 'int' declaration specifier", loc,
+                CurToken().GetSpelling().length());
         return false;
       }
       if (type_spec == TypeSpecifier::kShort ||
@@ -881,11 +888,10 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
         type_decl->m_has_int_specifier = true;
         return true;
       }
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv(
+      BailOut(llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
                   type_spec),
-              loc);
+              loc, CurToken().GetSpelling().length());
       return false;
     }
 
@@ -903,11 +909,10 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
         type_decl->m_type_specifier = TypeSpecifier::kLongDouble;
         return true;
       }
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv(
+      BailOut(llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
                   type_spec),
-              loc);
+              loc, CurToken().GetSpelling().length());
       return false;
     }
 
@@ -918,11 +923,10 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
         type_decl->m_type_specifier = TypeSpecifier::kShort;
         return true;
       }
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv(
+      BailOut(llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
                   type_spec),
-              loc);
+              loc, CurToken().GetSpelling().length());
       return false;
     }
 
@@ -933,11 +937,10 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
         type_decl->m_type_specifier = TypeSpecifier::kChar;
         return true;
       }
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv(
+      BailOut(llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
                   type_spec),
-              loc);
+              loc, CurToken().GetSpelling().length());
       return false;
     }
 
@@ -945,8 +948,8 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       // "double" can be combined with "long" to form "long double", but it
       // cannot be combined with signedness specifier.
       if (type_decl->m_sign_specifier != SignSpecifier::kUnknown) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                "'double' cannot be signed or unsigned", loc);
+        BailOut("'double' cannot be signed or unsigned", loc,
+                CurToken().GetSpelling().length());
         return false;
       }
       if (type_spec == TypeSpecifier::kUnknown) {
@@ -956,11 +959,10 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
         type_decl->m_type_specifier = TypeSpecifier::kLongDouble;
         return true;
       }
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv(
+      BailOut(llvm::formatv(
                   "cannot combine with previous '{0}' declaration specifier",
                   type_spec),
-              loc);
+              loc, CurToken().GetSpelling().length());
       return false;
     }
 
@@ -973,18 +975,16 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       // These types cannot have signedness or be combined with any other type
       // specifiers.
       if (type_decl->m_sign_specifier != SignSpecifier::kUnknown) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv("'{0}' cannot be signed or unsigned",
+        BailOut(llvm::formatv("'{0}' cannot be signed or unsigned",
                               ToTypeSpecifier(kind)),
-                loc);
+                loc, CurToken().GetSpelling().length());
         return false;
       }
       if (type_spec != TypeSpecifier::kUnknown) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv(
+        BailOut(llvm::formatv(
                     "cannot combine with previous '{0}' declaration specifier",
                     type_spec),
-                loc);
+                loc, CurToken().GetSpelling().length());
       }
       type_decl->m_type_specifier = ToTypeSpecifier(kind);
       return true;
@@ -995,11 +995,10 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
       // "signed" and "unsigned" cannot be combined with another signedness
       // specifier.
       if (type_decl->m_sign_specifier != SignSpecifier::kUnknown) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv(
+        BailOut(llvm::formatv(
                     "cannot combine with previous '{0}' declaration specifier",
                     type_decl->m_sign_specifier),
-                loc);
+                loc, CurToken().GetSpelling().length());
         return false;
       }
       if (type_spec == TypeSpecifier::kVoid ||
@@ -1010,9 +1009,8 @@ bool DILParser::HandleSimpleTypeSpecifier(TypeDeclaration* type_decl) {
           type_spec == TypeSpecifier::kWChar ||
           type_spec == TypeSpecifier::kChar16 ||
           type_spec == TypeSpecifier::kChar32) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv("'{0}' cannot be signed or unsigned", type_spec),
-                loc);
+        BailOut(llvm::formatv("'{0}' cannot be signed or unsigned", type_spec),
+                loc, CurToken().GetSpelling().length());
         return false;
       }
 
@@ -1041,10 +1039,9 @@ ASTNodeUP DILParser::ParseStringLiteral() {
 
   if (string_literal.hadError) {
     // TODO: Use ErrorCode::kInvalidStringLiteral in the future.
-    BailOut(ErrorCode::kInvalidNumericLiteral,
-            llvm::formatv("Failed to parse token as string-literal: {0}",
+    BailOut(llvm::formatv("Failed to parse token as string-literal: {0}",
                           CurToken()),
-            loc);
+            loc, CurToken().GetSpelling().length());
     return std::make_unique<ErrorNode>();
   }
 
@@ -1520,8 +1517,8 @@ ASTNodeUP DILParser::ParsePostfixExpression() {
     // Parse the type definition and resolve the type.
     auto type_id = ParseTypeId(/*must_be_type_id*/ true);
     if (!type_id) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              "type name requires a specifier or qualifier", loc);
+      BailOut("type name requires a specifier or qualifier", loc,
+              CurToken().GetSpelling().length());
       return std::make_unique<ErrorNode>();
     }
     if (!type_id.value().IsValid()) {
@@ -1558,9 +1555,8 @@ ASTNodeUP DILParser::ParsePostfixExpression() {
         if (CurToken().Is(Token::l_paren)) {
           // TODO: Check if `member_id` is actually a member function of `lhs`.
           // If not, produce a more accurate diagnostic.
-          BailOut(ErrorCode::kNotImplemented,
-                  "member function calls are not supported",
-                  CurToken().GetLocation());
+          BailOut("member function calls are not supported",
+                  CurToken().GetLocation(), CurToken().GetSpelling().length());
         }
         lhs = BuildMemberOf(std::move(lhs), std::move(member_id),
                             token.GetKind() == Token::arrow,
@@ -1618,8 +1614,8 @@ ASTNodeUP DILParser::ParsePrimaryExpression() {
   } else if (m_dil_lexer.IsStringLiteral(CurToken().GetKind())) {
     // Note: Only expressions that consist of a single string literal can be
     // handled by DIL.
-    BailOut(ErrorCode::kNotImplemented, "string literals are not supported",
-            CurToken().GetLocation());
+    BailOut("string literals are not supported", CurToken().GetLocation(),
+            CurToken().GetSpelling().length());
     return std::make_unique<ErrorNode>();
   } else if (CurToken().Is(Token::kw_nullptr)) {
     return ParsePointerLiteral();
@@ -1632,10 +1628,9 @@ ASTNodeUP DILParser::ParsePrimaryExpression() {
       auto func_def = GetBuiltinFunctionDef(m_ctx_scope, identifier);
       if (!func_def) {
         BailOut(
-            ErrorCode::kNotImplemented,
             llvm::formatv("function '{0}' is not a supported builtin intrinsic",
                           identifier),
-            loc);
+            loc, identifier.length());
         return std::make_unique<ErrorNode>();
       }
       return ParseBuiltinFunction(loc, std::move(func_def));
@@ -1650,14 +1645,13 @@ ASTNodeUP DILParser::ParsePrimaryExpression() {
                                      m_use_dynamic, nullptr);
 
     if (!value) {
-      BailOut(ErrorCode::kUndeclaredIdentifier,
-              llvm::formatv("use of undeclared identifier '{0}'", identifier),
-              loc);
+      BailOut(llvm::formatv("use of undeclared identifier '{0}'", identifier),
+              loc, identifier.length());
       return std::make_unique<ErrorNode>();
     }
-    return std::make_unique<IdentifierNode>(
-        loc, identifier, m_use_dynamic, std::move(value),
-        /*is_rvalue*/ false, IsContextVar(identifier));
+    return std::make_unique<IdentifierNode>(loc, identifier, std::move(value),
+                                            /*is_rvalue*/ false,
+                                            IsContextVar(identifier));
   } else if (CurToken().Is(Token::l_paren)) {
     // Check in case this is an anonynmous namespace
     if (m_dil_lexer.LookAhead(1).Is(Token::identifier)
@@ -1689,14 +1683,13 @@ ASTNodeUP DILParser::ParsePrimaryExpression() {
                                        m_ctx_scope->CalculateTarget(),
                                        m_use_dynamic);
       if (!value) {
-        BailOut(ErrorCode::kUndeclaredIdentifier,
-                llvm::formatv("use of undeclared identifier '{0}'", identifier),
-                loc);
+        BailOut(llvm::formatv("use of undeclared identifier '{0}'", identifier),
+                loc, identifier.length());
         return std::make_unique<ErrorNode>();
       }
-      return std::make_unique<IdentifierNode>(
-          loc, identifier, m_use_dynamic, std::move(value),
-          /* is_rvalue */ false, IsContextVar(identifier));
+      return std::make_unique<IdentifierNode>(loc, identifier, std::move(value),
+                                              /* is_rvalue */ false,
+                                              IsContextVar(identifier));
     } else {
       m_dil_lexer.Advance();
       auto expr = ParseExpression();
@@ -1706,9 +1699,8 @@ ASTNodeUP DILParser::ParsePrimaryExpression() {
     }
   }
 
-  BailOut(ErrorCode::kInvalidExpressionSyntax,
-          llvm::formatv("Unexpected token: {0}", CurToken()),
-          CurToken().GetLocation());
+  BailOut(llvm::formatv("Unexpected token: {0}", CurToken()),
+          CurToken().GetLocation(), CurToken().GetSpelling().length());
   return std::make_unique<ErrorNode>();
 }
 
@@ -1756,10 +1748,8 @@ std::optional<CompilerType> DILParser::ParseTypeId(bool must_be_type_id) {
     if (!type.IsValid()) {
       if (must_be_type_id) {
         BailOut(
-            ErrorCode::kUndeclaredIdentifier,
-            llvm::formatv("unknown type name '{0}'",
-                          type_decl.m_user_typename),
-            type_loc);
+            llvm::formatv("unknown type name '{0}'", type_decl.m_user_typename),
+            type_loc, type_decl.m_user_typename.length());
         return bad_type;
       }
       return {};
@@ -1770,11 +1760,10 @@ std::optional<CompilerType> DILParser::ParseTypeId(bool must_be_type_id) {
       // Same-name identifiers should be preferred over typenames.
       // TODO: Make type accessible with 'class', 'struct' and 'union' keywords.
       if (must_be_type_id) {
-        BailOut(ErrorCode::kUndeclaredIdentifier,
-                llvm::formatv(
+        BailOut(llvm::formatv(
                     "must use '{0}' tag to refer to type '{1}' in this scope",
                     type.GetTypeTag(), type_decl.m_user_typename),
-                type_loc);
+                type_loc, type_decl.m_user_typename.length());
         return bad_type;
       }
       return {};
@@ -1785,11 +1774,10 @@ std::optional<CompilerType> DILParser::ParseTypeId(bool must_be_type_id) {
       // Same-name identifiers should be preferred over typenames.
       // TODO: Make type accessible with 'class', 'struct' and 'union' keywords.
       if (must_be_type_id) {
-        BailOut(ErrorCode::kUndeclaredIdentifier,
-                llvm::formatv(
+        BailOut(llvm::formatv(
                     "must use '{0}' tag to refer to type '{1}' in this scope",
                     type.GetTypeTag(), type_decl.m_user_typename),
-                type_loc);
+                type_loc, type_decl.m_user_typename.length());
         return bad_type;
       }
       return {};
@@ -1857,9 +1845,8 @@ bool DILParser::ParseTypeSpecifier(TypeDeclaration* type_decl) {
   if (IsSimpleTypeSpecifierKeyword(CurToken())) {
     // User-defined typenames can't be combined with builtin keywords.
     if (type_decl->m_is_user_type) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              "cannot combine with previous declaration specifier",
-              CurToken().GetLocation());
+      BailOut("cannot combine with previous declaration specifier",
+              CurToken().GetLocation(), CurToken().GetSpelling().length());
       type_decl->m_has_error = true;
       return false;
     }
@@ -1889,10 +1876,10 @@ bool DILParser::ParseTypeSpecifier(TypeDeclaration* type_decl) {
     uint32_t loc = CurToken().GetLocation();
 
     // Try parsing optional nested_name_specifier.
-    auto nested_name_specifier = ParseNestedNameSpecifier();
+    std::string nested_name_specifier = ParseNestedNameSpecifier();
 
     // Try parsing required type_name.
-    auto type_name = ParseTypeName();
+    std::string type_name = ParseTypeName();
 
     // If there is a type_name, then this is indeed a simple_type_specifier.
     // Global and qualified (namespace/class) scopes can be empty, since they're
@@ -1900,15 +1887,14 @@ bool DILParser::ParseTypeSpecifier(TypeDeclaration* type_decl) {
     if (!type_name.empty()) {
       // User-defined typenames can't be combined with builtin keywords.
       if (type_decl->m_is_builtin) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                "cannot combine with previous declaration specifier", loc);
+        BailOut("cannot combine with previous declaration specifier", loc, 1);
         type_decl->m_has_error = true;
         return false;
       }
       // There should be only one user-defined typename.
       if (type_decl->m_is_user_type) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                "two or more data types in declaration of 'type name'", loc);
+        BailOut("two or more data types in declaration of 'type name'", loc,
+                type_decl->m_user_typename.length());
         type_decl->m_has_error = true;
         return false;
       }
@@ -1937,22 +1923,20 @@ bool DILParser::ParseTypeSpecifier(TypeDeclaration* type_decl) {
 std::string DILParser::ParseNestedNameSpecifier() {
   // The first token in nested_name_specifier is always an identifier, or
   // '(anonymous namespace)'.
-  if (CurToken().IsNot(Token::identifier) && CurToken().IsNot(Token::l_paren)) {
-    return "";
-  }
+  switch (CurToken().GetKind()) {
+  case Token::l_paren: {
+    // Anonymous namespaces need to be treated specially: They are
+    // represented the the string '(anonymous namespace)', which has a space
+    // in it (throwing  off normal parsing) and is not actually proper C++>
+    // Check to see if we're looking at '(anonymous namespace)::...'
 
-  // Anonymous namespaces need to be treated specially: They are represented
-  // the the string '(anonymous namespace)', which has a space in it (throwing
-  // off normal parsing) and is not actually proper C++> Check to see if we're
-  // looking at '(anonymous namespace)::...'
-  if (CurToken().Is(Token::l_paren)) {
     // Look for all the pieces, in order:
     // l_paren 'anonymous' 'namespace' r_paren coloncolon
-    if (m_dil_lexer.LookAhead(1).Is(Token::identifier)
-        && (((Token)m_dil_lexer.LookAhead(1)).GetSpelling() == "anonymous")
-        && m_dil_lexer.LookAhead(2).Is(Token::kw_namespace)
-        && m_dil_lexer.LookAhead(3).Is(Token::r_paren)
-        && m_dil_lexer.LookAhead(4).Is(Token::coloncolon)) {
+    if (m_dil_lexer.LookAhead(1).Is(Token::identifier) &&
+        (m_dil_lexer.LookAhead(1).GetSpelling() == "anonymous") &&
+        m_dil_lexer.LookAhead(2).Is(Token::kw_namespace) &&
+        m_dil_lexer.LookAhead(3).Is(Token::r_paren) &&
+        m_dil_lexer.LookAhead(4).Is(Token::coloncolon)) {
       m_dil_lexer.Advance(4);
 
       assert(
@@ -1966,51 +1950,54 @@ std::string DILParser::ParseNestedNameSpecifier() {
         m_dil_lexer.Advance();
       }
       return "(anonymous namespace)::" + identifier2;
-    } else {
-      return "";
     }
+    return "";
   } // end of special handling for '(anonymous namespace)'
-
-  // If the next token is scope ("::"), then this is indeed a
-  // nested_name_specifier
-  if (m_dil_lexer.LookAhead(1).Is(Token::coloncolon)) {
-    // This nested_name_specifier is a single identifier.
-    std::string identifier = CurToken().GetSpelling();
-    m_dil_lexer.Advance(1);
-    Expect(Token::coloncolon);
-    m_dil_lexer.Advance();
-    // Continue parsing the nested_name_specifier.
-    return identifier + "::" + ParseNestedNameSpecifier();
-  }
-
-  // If the next token starts a template argument list, then we have a
-  // simple_template_id here.
-  if (m_dil_lexer.LookAhead(1).Is(Token::less)) {
-    // We don't know whether this will be a nested_name_identifier or just a
-    // type_name. Prepare to rollback if this is not a nested_name_identifier.
-
-    // Start tentative parsing (save token location/idx, for possible rollback).
-    uint32_t save_token_idx = m_dil_lexer.GetCurrentTokenIdx();
-
-    // TODO: Parse just the simple_template_id?
-    auto type_name = ParseTypeName();
-
-    // If we did parse the type_name successfully and it's followed by the scope
-    // operator ("::"), then this is indeed a nested_name_specifier. Continue
-    // parsing nested_name_specifier.
-    if (!type_name.empty() && CurToken().Is(Token::coloncolon)) {
+  case Token::identifier: {
+    // If the next token is scope ("::"), then this is indeed a
+    // nested_name_specifier
+    if (m_dil_lexer.LookAhead(1).Is(Token::coloncolon)) {
+      // This nested_name_specifier is a single identifier.
+      std::string identifier = CurToken().GetSpelling();
+      m_dil_lexer.Advance(1);
+      Expect(Token::coloncolon);
       m_dil_lexer.Advance();
       // Continue parsing the nested_name_specifier.
-      return type_name + "::" + ParseNestedNameSpecifier();
+      return identifier + "::" + ParseNestedNameSpecifier();
     }
 
-    // Not a nested_name_specifier, but could be just a type_name or something
-    // else entirely. Rollback the parser and try a different path.
+    // If the next token starts a template argument list, then we have a
+    // simple_template_id here.
+    if (m_dil_lexer.LookAhead(1).Is(Token::less)) {
+      // We don't know whether this will be a nested_name_identifier or just
+      // a type_name. Prepare to rollback if this is not a
+      // nested_name_identifier.
 
-    TentativeParsingRollback(save_token_idx);
+      // Start tentative parsing (save token location/idx, for possible
+      // rollback).
+      uint32_t save_token_idx = m_dil_lexer.GetCurrentTokenIdx();
+
+      // TODO: Parse just the simple_template_id?
+      std::string type_name = ParseTypeName();
+
+      // If we did parse the type_name successfully and it's followed by the
+      // scope parsing nested_name_specifier.
+      if (!type_name.empty() && CurToken().Is(Token::coloncolon)) {
+        m_dil_lexer.Advance();
+        // Continue parsing the nested_name_specifier.
+        return type_name + "::" + ParseNestedNameSpecifier();
+      }
+
+      // Not a nested_name_specifier, but could be just a type_name or
+      // something else entirely. Rollback the parser and try a different
+      // path.
+      TentativeParsingRollback(save_token_idx);
+    }
+    return "";
   }
-
-  return "";
+  default:
+    return "";
+  }
 }
 
 // Parse a type_name.
@@ -2265,7 +2252,7 @@ std::string DILParser::ParseIdExpression() {
   }
 
   // Try parsing optional nested_name_specifier.
-  auto nested_name_specifier = ParseNestedNameSpecifier();
+  std::string nested_name_specifier = ParseNestedNameSpecifier();
 
   // If nested_name_specifier is present, then it's qualified_id production.
   // Follow the first production rule.
@@ -2348,10 +2335,9 @@ ASTNodeUP DILParser::ParseCharLiteral() {
 
   if (char_literal.hadError()) {
     // TODO: Add new ErrorCode kInvalidCharLiteral and use it
-    BailOut(ErrorCode::kInvalidNumericLiteral,
-            llvm::formatv("Failed to parse token as char-constant: {0}",
+    BailOut(llvm::formatv("Failed to parse token as char-constant: {0}",
                           CurToken()),
-            CurToken().GetLocation());
+            CurToken().GetLocation(), CurToken().GetSpelling().length());
     CompilerType bad_type;
     return std::make_unique<ErrorNode>();
   }
@@ -2395,10 +2381,9 @@ ASTNodeUP DILParser::ParseNumericConstant() {
                                     /*AllowMicrosoftExt=*/true);
 
   if (literal.hadError) {
-    BailOut(ErrorCode::kInvalidNumericLiteral,
-            llvm::formatv("Failed to parse token as numeric-constant: {0}",
+    BailOut(llvm::formatv("Failed to parse token as numeric-constant: {0}",
                           CurToken()),
-            CurToken().GetLocation());
+            CurToken().GetLocation(), CurToken().GetSpelling().length());
     return std::make_unique<ErrorNode>();
   }
 
@@ -2413,11 +2398,10 @@ ASTNodeUP DILParser::ParseNumericConstant() {
   }
 
   // Don't care about anything else.
-  BailOut(ErrorCode::kInvalidNumericLiteral,
-          llvm::formatv(
+  BailOut(llvm::formatv(
               "numeric-constant should be either float or integer literal: {0}",
               CurToken()),
-          CurToken().GetLocation());
+          CurToken().GetLocation(), CurToken().GetSpelling().length());
   return std::make_unique<ErrorNode>();
 }
 
@@ -2434,9 +2418,8 @@ ASTNodeUP DILParser::ParseFloatingLiteral(dil::NumericLiteralParser &literal,
   // underflowed to zero (APFloat reports denormals as underflow).
   if ((result & llvm::APFloat::opOverflow) ||
       ((result & llvm::APFloat::opUnderflow) && raw_value.isZero())) {
-    BailOut(ErrorCode::kInvalidNumericLiteral,
-            llvm::formatv("float underflow/overflow happened: {0}", token),
-            token.GetLocation());
+    BailOut(llvm::formatv("float underflow/overflow happened: {0}", token),
+            token.GetLocation(), token.GetSpelling().length());
     CompilerType bad_type;
     return std::make_unique<ErrorNode>();
   }
@@ -2454,11 +2437,10 @@ ASTNodeUP DILParser::ParseIntegerLiteral(dil::NumericLiteralParser &literal,
   llvm::APInt raw_value(type_width<uintmax_t>(), 0);
 
   if (literal.GetIntegerValue(raw_value)) {
-    BailOut(ErrorCode::kInvalidNumericLiteral,
-            llvm::formatv("integer literal is too large to be represented in "
+    BailOut(llvm::formatv("integer literal is too large to be represented in "
                           "any integer type: {0}",
                           token),
-            token.GetLocation());
+            token.GetLocation(), token.GetSpelling().length());
     CompilerType bad_type;
     return std::make_unique<ErrorNode>();
   }
@@ -2522,13 +2504,12 @@ DILParser::ParseBuiltinFunction(uint32_t loc,
 
   // Check we have the correct number of arguments.
   if (arguments.size() != func_def->m_arguments.size()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv(
-                "no matching function for call to '{0}': requires {1} "
-                "argument(s), but {2} argument(s) were provided",
-                func_def->m_name, func_def->m_arguments.size(),
-                arguments.size()),
-            loc);
+    BailOut(
+        llvm::formatv("no matching function for call to '{0}': requires {1} "
+                      "argument(s), but {2} argument(s) were provided",
+                      func_def->m_name, func_def->m_arguments.size(),
+                      arguments.size()),
+        loc, 1);
     return std::make_unique<ErrorNode>();
   }
 
@@ -2571,11 +2552,10 @@ ASTNodeUP DILParser::BuildCStyleCast(CompilerType type, ASTNodeUP rhs,
     if (rhs_type.IsPointerType() || rhs_type.IsNullPtrType()) {
       // C-style cast from pointer to float/double is not allowed.
       if (type.IsFloat()) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv("C-style cast from {0} to {1} is not allowed",
+        BailOut(llvm::formatv("C-style cast from {0} to {1} is not allowed",
                               rhs_type.TypeDescription(),
                               type.TypeDescription()),
-                location);
+                location, type.TypeDescription().length());
         return std::make_unique<ErrorNode>();
       }
       // Casting pointer to bool is valid. Otherwise check if the result type
@@ -2587,20 +2567,18 @@ ASTNodeUP DILParser::BuildCStyleCast(CompilerType type, ASTNodeUP rhs,
       if (auto temp = rhs_type.GetByteSize(m_ctx_scope.get()))
         rhs_type_byte_size = temp.value();
       if (!type.IsBoolean() && type_byte_size < rhs_type_byte_size) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv(
+        BailOut(llvm::formatv(
                     "cast from pointer to smaller type {0} loses information",
                     type.TypeDescription()),
-                location);
+                location, type.TypeDescription().length());
         return std::make_unique<ErrorNode>();
       }
     } else if (!rhs_type.IsScalarType() && !rhs_type.IsEnumerationType()) {
       // Otherwise accept only arithmetic types and enums.
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv(
+      BailOut(llvm::formatv(
                   "cannot convert {0} to {1} without a conversion operator",
                   rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
     promo_kind = TypePromotionCastKind::eArithmetic;
@@ -2608,10 +2586,9 @@ ASTNodeUP DILParser::BuildCStyleCast(CompilerType type, ASTNodeUP rhs,
   } else if (type.IsEnumerationType()) {
     // Cast to enum type.
     if (!rhs_type.IsScalarType() && !rhs_type.IsEnumerationType()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("C-style cast from {0} to {1} is not allowed",
+      BailOut(llvm::formatv("C-style cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
     cast_kind = CStyleCastKind::eEnumeration;
@@ -2621,10 +2598,9 @@ ASTNodeUP DILParser::BuildCStyleCast(CompilerType type, ASTNodeUP rhs,
     if (!rhs_type.IsInteger() && !rhs_type.IsEnumerationType() &&
         !rhs_type.IsArrayType() && !rhs_type.IsPointerType() &&
         !rhs_type.IsNullPtrType()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("cannot cast from type {0} to pointer type {1}",
+      BailOut(llvm::formatv("cannot cast from type {0} to pointer type {1}",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
     promo_kind = TypePromotionCastKind::ePointer;
@@ -2632,10 +2608,9 @@ ASTNodeUP DILParser::BuildCStyleCast(CompilerType type, ASTNodeUP rhs,
   } else if (type.IsNullPtrType()) {
     // Cast to nullptr type.
     if (!rhs_type.IsNullPtrType() && !rhs->is_literal_zero()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("C-style cast from {0} to {1} is not allowed",
+      BailOut(llvm::formatv("C-style cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
     cast_kind = CStyleCastKind::eNullptr;
@@ -2643,20 +2618,18 @@ ASTNodeUP DILParser::BuildCStyleCast(CompilerType type, ASTNodeUP rhs,
   } else if (type.IsReferenceType()) {
     // Cast to a reference type.
     if (rhs->is_rvalue()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("C-style cast from rvalue to reference type {0}",
+      BailOut(llvm::formatv("C-style cast from rvalue to reference type {0}",
                             type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
     cast_kind = CStyleCastKind::eReference;
 
   } else {
     // Unsupported cast.
-    BailOut(ErrorCode::kNotImplemented,
-            llvm::formatv("casting of {0} to {1} is not implemented yet",
+    BailOut(llvm::formatv("casting of {0} to {1} is not implemented yet",
                           rhs_type.TypeDescription(), type.TypeDescription()),
-            location);
+            location, type.TypeDescription().length());
     return std::make_unique<ErrorNode>();
   }
 
@@ -2714,10 +2687,9 @@ ASTNodeUP DILParser::BuildCxxStaticCast(CompilerType type, ASTNodeUP rhs,
   }
 
   // Unsupported cast.
-  BailOut(ErrorCode::kNotImplemented,
-          llvm::formatv("casting of {0} to {1} is not implemented yet",
+  BailOut(llvm::formatv("casting of {0} to {1} is not implemented yet",
                         rhs_type.TypeDescription(), type.TypeDescription()),
-          location);
+          location, type.TypeDescription().length());
   CompilerType bad_type;
   return std::make_unique<ErrorNode>();
 }
@@ -2731,19 +2703,17 @@ ASTNodeUP DILParser::BuildCxxStaticCastToScalar(CompilerType type,
   if (rhs_type.IsPointerType() || rhs_type.IsNullPtrType()) {
     // Pointers can be casted to bools.
     if (!type.IsBoolean()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("static_cast from {0} to {1} is not allowed",
+      BailOut(llvm::formatv("static_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
   } else if (!rhs_type.IsScalarType() && !rhs_type.IsEnumerationType()) {
     // Otherwise accept only arithmetic types and enums.
     BailOut(
-        ErrorCode::kInvalidOperandType,
         llvm::formatv("cannot convert {0} to {1} without a conversion operator",
                       rhs_type.TypeDescription(), type.TypeDescription()),
-        location);
+        location, type.TypeDescription().length());
     return std::make_unique<ErrorNode>();
   }
 
@@ -2757,10 +2727,9 @@ ASTNodeUP DILParser::BuildCxxStaticCastToEnum(CompilerType type, ASTNodeUP rhs,
   auto rhs_type = rhs->GetDereferencedResultType();
 
   if (!rhs_type.IsScalarType() && !rhs_type.IsEnumerationType()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("static_cast from {0} to {1} is not allowed",
+    BailOut(llvm::formatv("static_cast from {0} to {1} is not allowed",
                           rhs_type.TypeDescription(), type.TypeDescription()),
-            location);
+            location, type.TypeDescription().length());
     CompilerType bad_type;
     return std::make_unique<ErrorNode>();
   }
@@ -2786,17 +2755,15 @@ ASTNodeUP DILParser::BuildCxxStaticCastToPointer(CompilerType type,
     }
 
     if (!type.IsPointerToVoid() && !rhs_type.IsPointerToVoid()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("static_cast from {0} to {1} is not allowed",
+      BailOut(llvm::formatv("static_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
   } else if (!rhs_type.IsNullPtrType() && !rhs->is_literal_zero()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("cannot cast from type {0} to pointer type '{1}'",
+    BailOut(llvm::formatv("cannot cast from type {0} to pointer type '{1}'",
                           rhs_type.TypeDescription(), type.TypeDescription()),
-            location);
+            location, type.TypeDescription().length());
     return std::make_unique<ErrorNode>();
   }
 
@@ -2811,10 +2778,9 @@ ASTNodeUP DILParser::BuildCxxStaticCastToNullPtr(CompilerType type,
   auto rhs_type = rhs->GetDereferencedResultType();
 
   if (!rhs_type.IsNullPtrType() && !rhs->is_literal_zero()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("static_cast from {0} to {1} is not allowed",
+    BailOut(llvm::formatv("static_cast from {0} to {1} is not allowed",
                           rhs_type.TypeDescription(), type.TypeDescription()),
-            location);
+            location, type.TypeDescription().length());
     CompilerType bad_type;
     return std::make_unique<ErrorNode>();
   }
@@ -2832,11 +2798,10 @@ ASTNodeUP DILParser::BuildCxxStaticCastToReference(CompilerType type,
   auto type_deref = type.GetNonReferenceType();
 
   if (rhs->is_rvalue()) {
-    BailOut(ErrorCode::kNotImplemented,
-            llvm::formatv("static_cast from rvalue of type {0} to reference "
+    BailOut(llvm::formatv("static_cast from rvalue of type {0} to reference "
                           "type {1} is not implemented yet",
                           rhs_type.TypeDescription(), type.TypeDescription()),
-            location);
+            location, type.TypeDescription().length());
     return std::make_unique<ErrorNode>();
   }
 
@@ -2850,10 +2815,9 @@ ASTNodeUP DILParser::BuildCxxStaticCastToReference(CompilerType type,
     return BuildCxxStaticCastForInheritedTypes(type, std::move(rhs), location);
   }
 
-  BailOut(ErrorCode::kNotImplemented,
-          llvm::formatv("static_cast from {0} to {1} is not implemented yet",
+  BailOut(llvm::formatv("static_cast from {0} to {1} is not implemented yet",
                         rhs_type.TypeDescription(), type.TypeDescription()),
-          location);
+          location, type.TypeDescription().length());
   return std::make_unique<ErrorNode>();
 }
 
@@ -2900,11 +2864,10 @@ ASTNodeUP DILParser::BuildCxxStaticCastForInheritedTypes(CompilerType type,
       // Base-to-derived conversion isn't possible for virtually inherited
       // types (either directly or indirectly).
       assert(virtual_base.IsValid() && "virtual base should be valid");
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("cannot cast {0} to {1} via virtual base {2}",
+      BailOut(llvm::formatv("cannot cast {0} to {1} via virtual base {2}",
                             rhs_type.TypeDescription(), type.TypeDescription(),
                             virtual_base.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
 
@@ -2912,11 +2875,10 @@ ASTNodeUP DILParser::BuildCxxStaticCastForInheritedTypes(CompilerType type,
                                                offset, is_rvalue);
   }
 
-  BailOut(ErrorCode::kInvalidOperandType,
-          llvm::formatv("static_cast from {0} to {1}, which are not "
+  BailOut(llvm::formatv("static_cast from {0} to {1}, which are not "
                         "related by inheritance, is not allowed",
                         rhs_type.TypeDescription(), type.TypeDescription()),
-          location);
+          location, type.TypeDescription().length());
   return std::make_unique<ErrorNode>();
 }
 
@@ -2929,10 +2891,9 @@ ASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, ASTNodeUP rhs,
   if (type.IsScalarType()) {
     // reinterpret_cast doesn't support non-integral scalar types.
     if (!type.IsInteger()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
+      BailOut(llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
 
@@ -2952,11 +2913,10 @@ ASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, ASTNodeUP rhs,
       if (auto temp = rhs_type.GetByteSize(m_ctx_scope.get()))
         rhs_type_byte_size = temp.value();
       if (type_byte_size < rhs_type_byte_size) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv(
+        BailOut(llvm::formatv(
                     "cast from pointer to smaller type {0} loses information",
                     type.TypeDescription()),
-                location);
+                location, type.TypeDescription().length());
         return std::make_unique<ErrorNode>();
       }
     } else if (type.IsTypedefType() || rhs_type.IsTypedefType()) {
@@ -2966,18 +2926,17 @@ ASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, ASTNodeUP rhs,
                                    rhs_type.GetTypedefedType() : rhs_type;
       if (!base_type.CompareTypes(rhs_base_type)) {
         // Integral type can be converted to its own type.
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
-                              rhs_type.TypeDescription(), type.TypeDescription()),
-                location);
+        BailOut(llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
+                              rhs_type.TypeDescription(),
+                              type.TypeDescription()),
+                location, type.TypeDescription().length());
         return std::make_unique<ErrorNode>();
       }
     } else if (!type.CompareTypes(rhs_type)) {
       // Integral type can be converted to its own type.
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
+      BailOut(llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
   } else if (type.IsEnumerationType()) {
@@ -2987,10 +2946,9 @@ ASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, ASTNodeUP rhs,
     CompilerType rhs_base_type = rhs_type.IsTypedefType() ?
                                  rhs_type.GetTypedefedType() : rhs_type;
     if (!base_type.CompareTypes(rhs_base_type)) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
+      BailOut(llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
 
@@ -3000,29 +2958,26 @@ ASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, ASTNodeUP rhs,
     // TODO: Implement an explicit node for array-to-pointer conversions.
     if (!rhs_type.IsInteger() && !rhs_type.IsEnumerationType() &&
         !rhs_type.IsArrayType() && !rhs_type.IsPointerType()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
+      BailOut(llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                             rhs_type.TypeDescription(), type.TypeDescription()),
-              location);
+              location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
 
   } else if (type.IsNullPtrType()) {
     // reinterpret_cast to nullptr_t isn't allowed (even for nullptr_t).
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
+    BailOut(llvm::formatv("reinterpret_cast from {0} to {1} is not allowed",
                           rhs_type.TypeDescription(), type.TypeDescription()),
-            location);
+            location, type.TypeDescription().length());
     return std::make_unique<ErrorNode>();
 
   } else if (type.IsReferenceType()) {
     // L-values can be converted to any reference type.
     if (rhs->is_rvalue()) {
       BailOut(
-          ErrorCode::kInvalidOperandType,
           llvm::formatv("reinterpret_cast from rvalue to reference type {0}",
                         type.TypeDescription()),
-          location);
+          location, type.TypeDescription().length());
       return std::make_unique<ErrorNode>();
     }
     // Casting to reference types gives an L-value result.
@@ -3030,10 +2985,9 @@ ASTNodeUP DILParser::BuildCxxReinterpretCast(CompilerType type, ASTNodeUP rhs,
 
   } else {
     // Unsupported cast.
-    BailOut(ErrorCode::kNotImplemented,
-            llvm::formatv("casting of {0} to {1} is not implemented yet",
+    BailOut(llvm::formatv("casting of {0} to {1} is not implemented yet",
                           rhs_type.TypeDescription(), type.TypeDescription()),
-            location);
+            location, type.TypeDescription().length());
     return std::make_unique<ErrorNode>();
   }
 
@@ -3052,19 +3006,17 @@ ASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, ASTNodeUP rhs,
   } else {
     // Dynamic casts are allowed only for pointers and references.
     BailOut(
-        ErrorCode::kInvalidOperandType,
         llvm::formatv("invalid target type {0} for dynamic_cast; target type "
                       "must be a reference or pointer type to a defined class",
                       type.TypeDescription()),
-        location);
+        location, type.TypeDescription().length());
     return std::make_unique<ErrorNode>();
   }
   // Dynamic casts are allowed only for record types.
   if (!pointee_type.IsRecordType()) {
-    BailOut(
-        ErrorCode::kInvalidOperandType,
-        llvm::formatv("{0} is not a class type", pointee_type.TypeDescription()),
-        location);
+    BailOut(llvm::formatv("{0} is not a class type",
+                          pointee_type.TypeDescription()),
+            location, 1);
     return std::make_unique<ErrorNode>();
   }
 
@@ -3075,33 +3027,30 @@ ASTNodeUP DILParser::BuildCxxDynamicCast(CompilerType type, ASTNodeUP rhs,
     expr_type = expr_type.GetNonReferenceType();
   } else {
     // Expression type must be a pointer or a reference.
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("cannot use dynamic_cast to convert from {0} to {1}",
+    BailOut(llvm::formatv("cannot use dynamic_cast to convert from {0} to {1}",
                           expr_type.TypeDescription(), type.TypeDescription()),
-            location);
+            location, type.TypeDescription().length());
     return std::make_unique<ErrorNode>();
   }
   // Dynamic casts are allowed only for record types.
   if (!expr_type.IsRecordType()) {
     BailOut(
-        ErrorCode::kInvalidOperandType,
         llvm::formatv("{0} is not a class type", expr_type.TypeDescription()),
-        location);
+        location, 1);
     return std::make_unique<ErrorNode>();
   }
 
   // Expr type must be polymorphic.
   if (!expr_type.IsPolymorphicClass()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("{0} is not polymorphic", expr_type.TypeDescription()),
-            location);
+    BailOut(
+        llvm::formatv("{0} is not polymorphic", expr_type.TypeDescription()),
+        location, 1);
     return std::make_unique<ErrorNode>();
   }
 
   // LLDB doesn't support dynamic_cast in the expression evaluator. We disable
   // it too to match the behaviour, but theoretically it can be implemented.
-  BailOut(ErrorCode::kInvalidOperandType,
-          "dynamic_cast is not supported in this context", location);
+  BailOut("dynamic_cast is not supported in this context", location, 1);
   return std::make_unique<ErrorNode>();
 }
 
@@ -3135,7 +3084,7 @@ ASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, ASTNodeUP rhs,
               std::unique_ptr<IdentifierInfo> new_info =
                   IdentifierInfo::FromValue(*child_sp);
               ASTNodeUP new_rhs = std::make_unique<IdentifierNode>(
-                  id_node->GetLocation(), id_node->GetName(), m_use_dynamic,
+                  id_node->GetLocation(), id_node->GetName(),
                   std::move(new_info), id_node->is_rvalue(),
                   id_node->is_context_var());
               rhs = std::move(new_rhs);
@@ -3157,11 +3106,10 @@ ASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, ASTNodeUP rhs,
         }
 
         if (!synthetic_child) {
-          BailOut(
-              ErrorCode::kInvalidOperandType,
-              llvm::formatv("indirection requires pointer operand ({0} invalid)",
-                            rhs_type.TypeDescription()),
-              location);
+          BailOut(llvm::formatv(
+                      "indirection requires pointer operand ({0} invalid)",
+                      rhs_type.TypeDescription()),
+                  location, 1);
           return std::make_unique<ErrorNode>();
         }
       }
@@ -3170,15 +3118,13 @@ ASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, ASTNodeUP rhs,
     case UnaryOpKind::AddrOf: {
       if (rhs->is_rvalue()) {
         BailOut(
-            ErrorCode::kInvalidOperandType,
             llvm::formatv("cannot take the address of an rvalue of type {0}",
                           rhs_type.TypeDescription()),
-            location);
+            location, 1);
         return std::make_unique<ErrorNode>();
       }
       if (rhs->is_bitfield()) {
-        BailOut(ErrorCode::kInvalidOperandType,
-                "address of bit-field requested", location);
+        BailOut("address of bit-field requested", location, 1);
         return std::make_unique<ErrorNode>();
       }
       result_type = rhs_type.GetPointerType();
@@ -3221,10 +3167,9 @@ ASTNodeUP DILParser::BuildUnaryOp(UnaryOpKind kind, ASTNodeUP rhs,
   }
 
   if (!result_type) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv(kInvalidOperandsToUnaryExpression,
+    BailOut(llvm::formatv(kInvalidOperandsToUnaryExpression,
                           rhs_type.TypeDescription()),
-            location);
+            location, 1);
     return std::make_unique<ErrorNode>();
   }
 
@@ -3380,11 +3325,10 @@ ASTNodeUP DILParser::BuildBinaryOp(BinaryOpKind kind, ASTNodeUP lhs,
                                           valobj_ptr);
   }
 
-  BailOut(ErrorCode::kInvalidOperandType,
-          llvm::formatv(kInvalidOperandsToBinaryExpression,
+  BailOut(llvm::formatv(kInvalidOperandsToBinaryExpression,
                         orig_lhs_type.TypeDescription(),
                         orig_rhs_type.TypeDescription()),
-          location);
+          location, 1);
   CompilerType bad_type;
   return std::make_unique<ErrorNode>();
 }
@@ -3395,10 +3339,9 @@ ASTNodeUP DILParser::BuildTernaryOp(ASTNodeUP cond, ASTNodeUP lhs,
   // First check if the condition contextually converted to bool.
   auto cond_type = cond->GetDereferencedResultType();
   if (!cond_type.IsContextuallyConvertibleToBool()) {
-    BailOut(
-        ErrorCode::kInvalidOperandType,
-        llvm::formatv(kValueIsNotConvertibleToBool, cond_type.TypeDescription()),
-        location);
+    BailOut(llvm::formatv(kValueIsNotConvertibleToBool,
+                          cond_type.TypeDescription()),
+            location, 1);
     return std::make_unique<ErrorNode>();
   }
 
@@ -3484,10 +3427,9 @@ ASTNodeUP DILParser::BuildTernaryOp(ASTNodeUP cond, ASTNodeUP lhs,
                                            std::move(lhs), std::move(rhs));
   }
 
-  BailOut(ErrorCode::kInvalidOperandType,
-          llvm::formatv("incompatible operand types ({0} and {1})",
+  BailOut(llvm::formatv("incompatible operand types ({0} and {1})",
                         lhs_type.TypeDescription(), rhs_type.TypeDescription()),
-          location);
+          location, 1);
   return std::make_unique<ErrorNode>();
 }
 
@@ -3527,13 +3469,11 @@ ASTNodeUP DILParser::BuildBinarySubscript(ASTNodeUP lhs, ASTNodeUP rhs,
         base = std::move(lhs);
         index = std::move(rhs);
       } else {
-        BailOut(ErrorCode::kInvalidOperandType,
-                "subscripted value is not an array or pointer", location);
+        BailOut("subscripted value is not an array or pointer", location, 1);
         return std::make_unique<ErrorNode>();
       }
     } else {
-      BailOut(ErrorCode::kInvalidOperandType,
-              "subscripted value is not an array or pointer", location);
+      BailOut("subscripted value is not an array or pointer", location, 1);
       return std::make_unique<ErrorNode>();
     }
   }
@@ -3544,15 +3484,13 @@ ASTNodeUP DILParser::BuildBinarySubscript(ASTNodeUP lhs, ASTNodeUP rhs,
 
   // Check if the index is of an integral type.
   if (!index_type.IsIntegerOrUnscopedEnumerationType()) {
-    BailOut(ErrorCode::kInvalidOperandType, "array subscript is not an integer",
-            location);
+    BailOut("array subscript is not an integer", location, 1);
     return std::make_unique<ErrorNode>();
   }
 
   auto base_type = base->GetDereferencedResultType();
   if (base_type.IsPointerToVoid()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            "subscript of pointer to incomplete type 'void'", location);
+    BailOut("subscript of pointer to incomplete type 'void'", location, 1);
     return std::make_unique<ErrorNode>();
   }
 
@@ -3581,11 +3519,10 @@ ASTNodeUP DILParser::BuildMemberOf(ASTNodeUP lhs, std::string member_id,
         lhs_valobj_sp = deref_sp;
         lhs_type = lhs_valobj_sp->GetCompilerType().GetPointerType();
       } else  {
-        BailOut(ErrorCode::kInvalidOperandType,
-                llvm::formatv("member reference type {0} is not a pointer; "
+        BailOut(llvm::formatv("member reference type {0} is not a pointer; "
                               "did you mean to use '.'?",
                               lhs_type.TypeDescription()),
-                location);
+                location, 2);
         return std::make_unique<ErrorNode>();
       }
     } else if (lhs_type.IsArrayType()) {
@@ -3599,22 +3536,20 @@ ASTNodeUP DILParser::BuildMemberOf(ASTNodeUP lhs, std::string member_id,
   } else {
     // "member of object" operator, check that LHS is an object.
     if (lhs_type.IsPointerType()) {
-      BailOut(ErrorCode::kInvalidOperandType,
-              llvm::formatv("member reference type {0} is a pointer; "
+      BailOut(llvm::formatv("member reference type {0} is a pointer; "
                             "did you mean to use '->'?",
                             lhs_type.TypeDescription()),
-              location);
+              location, 1);
       return std::make_unique<ErrorNode>();
     }
   }
 
   // Check if LHS is a record type, i.e. class/struct or union.
   if (!lhs_type.IsRecordType()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv(
+    BailOut(llvm::formatv(
                 "member reference base type {0} is not a structure or union",
                 lhs_type.TypeDescription()),
-            location);
+            location, 1);
     return std::make_unique<ErrorNode>();
   }
 
@@ -3622,10 +3557,9 @@ ASTNodeUP DILParser::BuildMemberOf(ASTNodeUP lhs, std::string member_id,
                                          UseSynthetic(), is_arrow);
 
   if (!opt_member) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("no member named '{0}' in {1}", member_id,
+    BailOut(llvm::formatv("no member named '{0}' in {1}", member_id,
                           lhs_type.GetFullyUnqualifiedType().TypeDescription()),
-            location);
+            location, member_id.length());
     return std::make_unique<ErrorNode>();
   }
 
@@ -3655,18 +3589,16 @@ ASTNodeUP DILParser::BuildMemberOf(ASTNodeUP lhs, std::string member_id,
 
 void DILParser::Expect(Token::Kind kind) {
   if (CurToken().IsNot(kind)) {
-    BailOut(ErrorCode::kUnknown,
-            llvm::formatv("expected {0}, got: {1}", kind, CurToken()),
-            CurToken().GetLocation());
+    BailOut(llvm::formatv("expected {0}, got: {1}", kind, CurToken()),
+            CurToken().GetLocation(), CurToken().GetSpelling().length());
   }
 }
 
 void DILParser::ExpectOneOf(std::vector<Token::Kind> kinds_vec) {
   if (!CurToken().IsOneOf(kinds_vec)) {
-    BailOut(ErrorCode::kUnknown,
-            llvm::formatv("expected any of ({0}), got: {1}",
+    BailOut(llvm::formatv("expected any of ({0}), got: {1}",
                           llvm::iterator_range(kinds_vec), CurToken()),
-            CurToken().GetLocation());
+            CurToken().GetLocation(), CurToken().GetSpelling().length());
   }
 }
 
@@ -3687,15 +3619,13 @@ ASTNodeUP DILParser::BuildIncrementDecrement(UnaryOpKind kind, ASTNodeUP rhs,
   // modify the context variable. However, MSVC debugger doesn't allow it, so we
   // don't implement it too.
   if (rhs->is_rvalue()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("expression is not assignable"), location);
+    BailOut(llvm::formatv("expression is not assignable"), location, 1);
     return std::make_unique<ErrorNode>();
   }
   if (!rhs->is_context_var() && !AllowSideEffects()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("side effects are not supported in this context: "
+    BailOut(llvm::formatv("side effects are not supported in this context: "
                           "trying to modify data at the target process"),
-            location);
+            location, 1);
     return std::make_unique<ErrorNode>();
   }
   llvm::StringRef op_name =
@@ -3703,17 +3633,15 @@ ASTNodeUP DILParser::BuildIncrementDecrement(UnaryOpKind kind, ASTNodeUP rhs,
           ? "increment"
           : "decrement";
   if (rhs_type.IsEnumerationType()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("cannot {0} expression of enum type '{1}'", op_name,
+    BailOut(llvm::formatv("cannot {0} expression of enum type '{1}'", op_name,
                           rhs_type.GetTypeName()),
-            location);
+            location, 1);
     return std::make_unique<ErrorNode>();
   }
   if (!rhs_type.IsScalarType() && !rhs_type.IsPointerType()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("cannot {0} value of type '{1}'", op_name,
+    BailOut(llvm::formatv("cannot {0} value of type '{1}'", op_name,
                           rhs_type.GetTypeName()),
-            location);
+            location, 1);
     return std::make_unique<ErrorNode>();
   }
 
@@ -3757,8 +3685,7 @@ CompilerType DILParser::PrepareBinaryAddition(ASTNodeUP &lhs, ASTNodeUP &rhs,
   }
 
   if (ptr_type.IsPointerToVoid()) {
-    BailOut(ErrorCode::kInvalidOperandType, "arithmetic on a pointer to void",
-            location);
+    BailOut("arithmetic on a pointer to void", location, 1);
     return bad_type;
   }
 
@@ -3787,8 +3714,7 @@ CompilerType DILParser::PrepareBinarySubtraction(ASTNodeUP &lhs, ASTNodeUP &rhs,
 
   if (lhs_type.IsPointerType() && rhs_type.IsInteger()) {
     if (lhs_type.IsPointerToVoid()) {
-      BailOut(ErrorCode::kInvalidOperandType, "arithmetic on a pointer to void",
-              location);
+      BailOut("arithmetic on a pointer to void", location, 1);
       return bad_type;
     }
 
@@ -3797,8 +3723,7 @@ CompilerType DILParser::PrepareBinarySubtraction(ASTNodeUP &lhs, ASTNodeUP &rhs,
 
   if (lhs_type.IsPointerType() && rhs_type.IsPointerType()) {
     if (lhs_type.IsPointerToVoid() && rhs_type.IsPointerToVoid()) {
-      BailOut(ErrorCode::kInvalidOperandType, "arithmetic on pointers to void",
-              location);
+      BailOut("arithmetic on pointers to void", location, 1);
       return bad_type;
     }
 
@@ -3811,11 +3736,10 @@ CompilerType DILParser::PrepareBinarySubtraction(ASTNodeUP &lhs, ASTNodeUP &rhs,
         lhs_unqualified_type.CompareTypes(rhs_unqualified_type);
 
     if (!comparable) {
-      BailOut(
-          ErrorCode::kInvalidOperandType,
-          llvm::formatv("{0} and {1} are not pointers to compatible types",
-                        lhs_type.TypeDescription(), rhs_type.TypeDescription()),
-          location);
+      BailOut(llvm::formatv("{0} and {1} are not pointers to compatible types",
+                            lhs_type.TypeDescription(),
+                            rhs_type.TypeDescription()),
+              location, 1);
       return bad_type;
     }
 
@@ -3979,11 +3903,10 @@ CompilerType DILParser::PrepareBinaryComparison(BinaryOpKind kind,
           lhs_unqualified_type.CompareTypes(rhs_unqualified_type);
 
       if (!comparable) {
-        BailOut(
-            ErrorCode::kInvalidOperandType,
-            llvm::formatv("comparison of distinct pointer types ({0} and {1})",
-                          lhs_type.TypeDescription(), rhs_type.TypeDescription()),
-            location);
+        BailOut(llvm::formatv(
+                    "comparison of distinct pointer types ({0} and {1})",
+                    lhs_type.TypeDescription(), rhs_type.TypeDescription()),
+                location, 1);
         return bad_type;;
       }
     }
@@ -4013,17 +3936,15 @@ CompilerType DILParser::PrepareBinaryLogical(const ASTNodeUP &lhs,
 
   if (!lhs_type.IsContextuallyConvertibleToBool()) {
     BailOut(
-        ErrorCode::kInvalidOperandType,
         llvm::formatv(kValueIsNotConvertibleToBool, lhs_type.TypeDescription()),
-        lhs->GetLocation());
+        lhs->GetLocation(), 1);
     return bad_type;
   }
 
   if (!rhs_type.IsContextuallyConvertibleToBool()) {
     BailOut(
-        ErrorCode::kInvalidOperandType,
         llvm::formatv(kValueIsNotConvertibleToBool, rhs_type.TypeDescription()),
-        rhs->GetLocation());
+        rhs->GetLocation(), 1);
     return bad_type;
   }
 
@@ -4043,15 +3964,13 @@ DILParser::PrepareCompositeAssignment(CompilerType comp_assign_type,
   // allow it, so we don't implement it too.
   CompilerType bad_type;
   if (lhs->is_rvalue()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("expression is not assignable"), location);
+    BailOut(llvm::formatv("expression is not assignable"), location, 1);
     return bad_type;
   }
   if (!lhs->is_context_var() && !AllowSideEffects()) {
-    BailOut(ErrorCode::kInvalidOperandType,
-            llvm::formatv("side effects are not supported in this context: "
+    BailOut(llvm::formatv("side effects are not supported in this context: "
                           "trying to modify data at the target process"),
-            location);
+            location, 1);
     return bad_type;
   }
 
@@ -4063,35 +3982,24 @@ DILParser::PrepareCompositeAssignment(CompilerType comp_assign_type,
     return lhs_type;
   }
 
-  BailOut(ErrorCode::kInvalidOperandType,
-          llvm::formatv("no known conversion from {0} to {1}",
+  BailOut(llvm::formatv("no known conversion from {0} to {1}",
                         comp_assign_type.TypeDescription(),
                         lhs_type.TypeDescription()),
-          location);
+          location, 1);
   return bad_type;
 }
 
-void DILParser::BailOut(ErrorCode code, const std::string& error,
-                        uint32_t loc) {
-  if (m_error.Fail()) {
+void DILParser::BailOut(const std::string &error, uint32_t loc,
+                        uint16_t err_len) {
+  if (m_error) {
     // If error is already set, then the parser is in the "bail-out" mode. Don't
     // do anything and keep the original error.
     return;
   }
 
-  m_error = Status((uint32_t) code, lldb::eErrorTypeGeneric,
-                   FormatDiagnostics(m_input_expr, error, loc));
-  // Advance the lexer token index to the end of the lexed tokens vector.
-  m_dil_lexer.ResetTokenIdx(m_dil_lexer.NumLexedTokens() - 1);
-}
+  m_error =
+      llvm::make_error<DILDiagnosticError>(m_input_expr, error, loc, err_len);
 
-void DILParser::BailOut(Status error) {
-  if (m_error.Fail()) {
-    // If error is already set, then the parser is in the "bail-out" mode. Don't
-    // do anything and keep the original error.
-    return;
-  }
-  m_error = std::move(error);
   // Advance the lexer token index to the end of the lexed tokens vector.
   m_dil_lexer.ResetTokenIdx(m_dil_lexer.NumLexedTokens() - 1);
 }
@@ -4149,10 +4057,9 @@ ASTNodeUP DILParser::InsertImplicitConversion(ASTNodeUP expr,
     llvm_unreachable("invalid implicit cast kind");
   }
 
-  BailOut(ErrorCode::kInvalidOperandType,
-          llvm::formatv("no known conversion from {0} to {1}",
+  BailOut(llvm::formatv("no known conversion from {0} to {1}",
                         expr_type.TypeDescription(), type.TypeDescription()),
-          expr->GetLocation());
+          expr->GetLocation(), 1);
   CompilerType bad_type;
   return std::make_unique<ErrorNode>();
 }

--- a/lldb/test/API/commands/frame/var-dil/basics/Indirection/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/basics/Indirection/main.cpp
@@ -2,12 +2,12 @@ int
 main(int argc, char **argv)
 {
   int val = 1;
-  int* p = &val;
+  int *p = &val;
 
-  typedef int* myp;
+  typedef int *myp;
   myp my_p = &val;
 
-  typedef int*& mypr;
+  typedef int *&mypr;
   mypr my_pr = p;
 
   return 0; // Set a breakpoint here

--- a/lldb/unittests/DIL/DILTests.cpp
+++ b/lldb/unittests/DIL/DILTests.cpp
@@ -740,8 +740,8 @@ TEST_F(EvalTest, TestPointerArithmetic) {
   EXPECT_THAT(Eval("+array_ref"), IsOk());
   EXPECT_THAT(Eval("-array"),
               IsError("invalid argument type 'int *' to unary expression\n"
-                      "-array\n"
-                      "^"));
+                      "   1 | -array\n"
+                      "     | ^"));
 
   EXPECT_THAT(Eval("array + 1"), IsOk());
   EXPECT_THAT(Eval("1 + array"), IsOk());
@@ -753,8 +753,8 @@ TEST_F(EvalTest, TestPointerArithmetic) {
   EXPECT_THAT(
       Eval("1 - array"),
       IsError("invalid operands to binary expression ('int' and 'int[10]')\n"
-              "1 - array\n"
-              "  ^"));
+              "   1 | 1 - array\n"
+              "     |   ^"));
 
   EXPECT_THAT(Eval("array - array"), IsEqual("0"));
   EXPECT_THAT(Eval("array - array_ref"), IsEqual("0"));
@@ -763,8 +763,8 @@ TEST_F(EvalTest, TestPointerArithmetic) {
       Eval("array + array"),
       IsError(
           "invalid operands to binary expression ('int[10]' and 'int[10]')\n"
-          "array + array\n"
-          "      ^"));
+          "   1 | array + array\n"
+          "     |       ^"));
 }
 
 TEST_F(EvalTest, PointerPointerArithmeticFloat) {
@@ -954,18 +954,18 @@ TEST_F(EvalTest, TestLogicalOperators) {
 
   EXPECT_THAT(Eval("false || !s"),
               IsError("invalid argument type 'S' to unary expression\n"
-                      "false || !s\n"
-                      "         ^"));
+                      "   1 | false || !s\n"
+                      "     |          ^"));
   EXPECT_THAT(
       Eval("s || false"),
       IsError("value of type 'S' is not contextually convertible to 'bool'\n"
-              "s || false\n"
-              "^"));
+              "   1 | s || false\n"
+              "     | ^"));
   EXPECT_THAT(
       Eval("true || s"),
       IsError("value of type 'S' is not contextually convertible to 'bool'\n"
-              "true || s\n"
-              "        ^"));
+              "   1 | true || s\n"
+              "     |         ^"));
   EXPECT_THAT(
       Eval("s ? 1 : 2"),
       IsError("value of type 'S' is not contextually convertible to 'bool'"));
@@ -999,12 +999,11 @@ TEST_F(EvalTest, TestMemberOf) {
   EXPECT_THAT(Eval("sarr->r + 1"), IsEqual("3"));
   EXPECT_THAT(Eval("(sarr + 1)->x"), IsEqual("1"));
 
-  EXPECT_THAT(
-      Eval("sp->4"),
-      IsError(
-          "<expr:1:5>: expected 'identifier', got: <'4' (numeric_constant)>\n"
-          "sp->4\n"
-          "    ^"));
+  EXPECT_THAT(Eval("sp->4"),
+              IsError(
+                  "expected 'identifier', got: <'4' (numeric_constant)>\n"
+                  "   1 | sp->4\n"
+                  "     |     ^"));
   EXPECT_THAT(Eval("sp->foo"), IsError("no member named 'foo' in 'Sx'"));
   EXPECT_THAT(
       Eval("sp->r / (void*)0"),
@@ -1093,11 +1092,15 @@ TEST_F(EvalTest, TestMemberOfAnonymousMember) {
 }
 
 TEST_F(EvalTest, TestGlobalVariableLookup) {
+  // For reference variables DIL gives both the pointer address & the value,
+  // but lldb only gives the value.
+  this->compare_with_lldb_ = false;
+
   EXPECT_THAT(Eval("globalVar"), IsEqual("-559038737")); // 0xDEADBEEF
   EXPECT_THAT(Eval("globalPtr"), IsOk());
-  EXPECT_THAT(Eval("globalRef"), IsEqual("-559038737"));
+  EXPECT_THAT(Eval("globalRef"), IsOk());
   EXPECT_THAT(Eval("::globalPtr"), IsOk());
-  EXPECT_THAT(Eval("::globalRef"), IsEqual("-559038737"));
+  EXPECT_THAT(Eval("::globalRef"), IsOk());
 
   EXPECT_THAT(Eval("externGlobalVar"),
               IsEqual("12648430")); // 0x00C0FFEE
@@ -1105,7 +1108,7 @@ TEST_F(EvalTest, TestGlobalVariableLookup) {
 
   EXPECT_THAT(Eval("ns::globalVar"), IsEqual("13"));
   EXPECT_THAT(Eval("ns::globalPtr"), IsOk());
-  EXPECT_THAT(Eval("ns::globalRef"), IsEqual("13"));
+  EXPECT_THAT(Eval("ns::globalRef"), IsOk());
   EXPECT_THAT(Eval("::ns::globalVar"), IsEqual("13"));
   EXPECT_THAT(Eval("::ns::globalPtr"), IsOk());
 }
@@ -1124,6 +1127,7 @@ TEST_F(EvalTest, TestInstanceVariables) {
 }
 
 TEST_F(EvalTest, TestIndirection) {
+  this->compare_with_lldb_ = false;
   EXPECT_THAT(Eval("*p"), IsEqual("1"));
   EXPECT_THAT(Eval("p"), IsOk());
   EXPECT_THAT(Eval("*my_p"), IsEqual("1"));
@@ -1138,6 +1142,7 @@ TEST_F(EvalTest, TestIndirection) {
 }
 
 TEST_F(EvalTest, TestAddressOf) {
+  this->compare_with_lldb_ = false;
   EXPECT_THAT(Eval("&x"), IsOk());
   EXPECT_THAT(Eval("r"), IsOk());
   EXPECT_THAT(Eval("&r"), IsOk());
@@ -1256,23 +1261,20 @@ TEST_F(EvalTest, TestCStyleCastBuiltins) {
   EXPECT_THAT(Eval("(long long**)1"), IsOk());
   EXPECT_THAT(Eval("(const long const long const* const const)1"), IsOk());
 
-  EXPECT_THAT(
-      Eval("(long&*)1"),
-      IsError(
-          "'type name' declared as a pointer to a reference of type 'long &'\n"
-          "(long&*)1\n"
-          "      ^"));
+  EXPECT_THAT(Eval("(long&*)1"), IsError("'type name' declared as a pointer to "
+                                         "a reference of type 'long &'\n"
+                                         "   1 | (long&*)1\n"
+                                         "     |       ^"));
 
   EXPECT_THAT(Eval("(long& &)1"),
               IsError("type name declared as a reference to a reference\n"
-                      "(long& &)1\n"
-                      "       ^"));
+                      "   1 | (long& &)1\n"
+                      "     |        ^"));
 
-  EXPECT_THAT(
-      Eval("(long 1)1"),
-      IsError("<expr:1:7>: expected 'r_paren', got: <'1' (numeric_constant)>\n"
-              "(long 1)1\n"
-              "      ^"));
+  EXPECT_THAT(Eval("(long 1)1"),
+              IsError("expected 'r_paren', got: <'1' (numeric_constant)>\n"
+                      "   1 | (long 1)1\n"
+                      "     |       ^"));
 }
 
 TEST_F(EvalTest, TestCStyleCastBasicType) {
@@ -1965,8 +1967,8 @@ TEST_F(EvalTest, TestBasicTypeDeclaration) {
   EXPECT_THAT(
       Eval("(int int)0"),
       IsError("cannot combine with previous 'int' declaration specifier\n"
-              "(int int)0\n"
-              "     ^"));
+              "   1 | (int int)0\n"
+              "     |      ^"));
   EXPECT_THAT(
       Eval("(char int)0"),
       IsError("cannot combine with previous 'char' declaration specifier"));
@@ -2107,9 +2109,9 @@ TEST_F(EvalTest, TestTemplateCpp11) {
 
   // Here T_1 is a local variable.
   EXPECT_THAT(Eval("T_1<2>1"), IsEqual("false"));  // (p < 2) > 1
-  // EXPECT_THAT(Eval("T_1<2>>1"), IsEqual("false")); // (p < 2) >> 1
+  EXPECT_THAT(Eval("T_1<2>>1"), XFail(IsEqual("false"))); // (p < 2) >> 1
   EXPECT_THAT(Eval("T_1<2>>1"),
-              IsError("<expr:1:7>: Unexpected token: <'>' (greater)>"));
+              IsError("Unexpected token: <'>' (greater)>"));
   // And here it's a template.
   EXPECT_THAT(Eval("T_1<int>::cx + 1"), IsEqual("25"));
 }
@@ -2430,10 +2432,11 @@ TEST_F(EvalTest, TestScopedEnumArithmetic) {
   EXPECT_THAT(Eval("+enum_foo"), IsError("invalid argument type"));
   EXPECT_THAT(Eval("-enum_foo"), IsError("invalid argument type"));
   EXPECT_THAT(Eval("~enum_foo"), IsError("invalid argument type"));
-  EXPECT_THAT(Eval("!enum_foo"),
-              IsError("invalid argument type 'ScopedEnum' to unary expression\n"
-                      "!enum_foo\n"
-                      "^"));
+  EXPECT_THAT(
+      Eval("!enum_foo"),
+      IsError("invalid argument type 'ScopedEnum' to unary expression\n"
+              "   1 | !enum_foo\n"
+              "     | ^"));
 }
 
 TEST_F(EvalTest, TestScopedEnumWithUnderlyingType) {
@@ -2443,6 +2446,7 @@ TEST_F(EvalTest, TestScopedEnumWithUnderlyingType) {
 }
 
 TEST_F(EvalTest, TestUnscopedEnum) {
+  this->compare_with_lldb_ = false;
   EXPECT_THAT(Eval("enum_one"), IsEqual("kOne"));
   EXPECT_THAT(Eval("enum_two"), IsEqual("kTwo"));
 
@@ -2495,8 +2499,8 @@ TEST_F(EvalTest, TestUnscopedEnum) {
               IsEqual(Is32Bit() ? "0x00000001" : "0x0000000000000001"));
 
   // Use references.
-  EXPECT_THAT(Eval("enum_one_ref"), IsEqual("kOne"));
-  EXPECT_THAT(Eval("enum_two_ref"), IsEqual("kTwo"));
+  EXPECT_THAT(Eval("enum_one_ref"), IsOk());
+  EXPECT_THAT(Eval("enum_two_ref"), IsOk());
   EXPECT_THAT(Eval("enum_one_ref == enum_one"), IsEqual("true"));
   EXPECT_THAT(Eval("enum_one_ref != enum_one"), IsEqual("false"));
   EXPECT_THAT(Eval("enum_one_ref == enum_two"), IsEqual("false"));
@@ -2605,33 +2609,35 @@ TEST_F(EvalTest, TestTernaryOperator) {
 
   EXPECT_THAT(Eval("true ? t : 1"),
               IsError("incompatible operand types ('T' and 'int')\n"
-                      "true ? t : 1\n"
-                      "     ^"));
+                      "   1 | true ? t : 1\n"
+                      "     |      ^"));
   EXPECT_THAT(Eval("true ? 1 : t"),
               IsError("incompatible operand types ('int' and 'T')\n"
-                      "true ? 1 : t\n"
-                      "     ^"));
+                      "   1 | true ? 1 : t\n"
+                      "     |      ^"));
   EXPECT_THAT(Eval("true ? (int*)15 : 1"),
               IsError("incompatible operand types ('int *' and 'int')\n"
-                      "true ? (int*)15 : 1\n"
-                      "     ^"));
+                      "   1 | true ? (int*)15 : 1\n"
+                      "     |      ^"));
   EXPECT_THAT(Eval("true ? arr2 : dbl_arr"),
               IsError("incompatible operand types ('int *' and 'double *')\n"
-                      "true ? arr2 : dbl_arr\n"
-                      "     ^"));
+                      "   1 | true ? arr2 : dbl_arr\n"
+                      "     |      ^"));
 
   EXPECT_THAT(Eval("&(true ? *pi : 0)"),
               IsError("cannot take the address of an rvalue of type 'int'\n"
-                      "&(true ? *pi : 0)\n"
-                      "^"));
-  EXPECT_THAT(Eval("&(true ? arr2 : pi)"),
-              IsError("cannot take the address of an rvalue of type 'int *'\n"
-                      "&(true ? arr2 : pi)\n"
-                      "^"));
-  EXPECT_THAT(Eval("&(true ? arr2 : arr3)"),
-              IsError("cannot take the address of an rvalue of type 'int *'\n"
-                      "&(true ? arr2 : arr3)\n"
-                      "^"));
+                      "   1 | &(true ? *pi : 0)\n"
+                      "     | ^"));
+  EXPECT_THAT(
+      Eval("&(true ? arr2 : pi)"),
+      IsError("cannot take the address of an rvalue of type 'int *'\n"
+              "   1 | &(true ? arr2 : pi)\n"
+              "     | ^"));
+  EXPECT_THAT(
+      Eval("&(true ? arr2 : arr3)"),
+      IsError("cannot take the address of an rvalue of type 'int *'\n"
+              "   1 | &(true ? arr2 : arr3)\n"
+              "     | ^"));
 
   EXPECT_THAT(Eval("true ? nullptr : pi"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
@@ -2667,17 +2673,16 @@ TEST_F(EvalTest, TestSizeOf) {
   // Makes sure that the expression isn't parsed as two types `i<i>` and `i`.
   EXPECT_THAT(Eval("sizeof(i < i > i)"), IsEqual("1"));
 
-  EXPECT_THAT(
-      Eval("sizeof(int & *)"),
-      IsError(
-          "'type name' declared as a pointer to a reference of type 'int &'\n"
-          "sizeof(int & *)\n"
-          "             ^"));
+  EXPECT_THAT(Eval("sizeof(int & *)"),
+              IsError("'type name' declared as a pointer to a reference of "
+                      "type 'int &'\n"
+                      "   1 | sizeof(int & *)\n"
+                      "     |              ^"));
 
   EXPECT_THAT(Eval("sizeof(intt + 1)"),
               IsError("use of undeclared identifier 'intt'\n"
-                      "sizeof(intt + 1)\n"
-                      "       ^"));
+                      "   1 | sizeof(intt + 1)\n"
+                      "     |        ^"));
 }
 
 TEST_F(EvalTest, TestBuiltinFunction_Log2) {
@@ -2710,20 +2715,20 @@ TEST_F(EvalTest, TestBuiltinFunction_Log2) {
 
   EXPECT_THAT(Eval("__log2(foo)"),
               IsError("no known conversion from 'Foo' to 'unsigned int'\n"
-                      "__log2(foo)\n"
-                      "       ^"));
+                      "   1 | __log2(foo)\n"
+                      "     |        ^"));
 
   EXPECT_THAT(Eval("__log2()"),
               IsError("no matching function for call to '__log2': requires 1 "
                       "argument(s), but 0 argument(s) were provided\n"
-                      "__log2()\n"
-                      "^"));
+                      "   1 | __log2()\n"
+                      "     | ^"));
 
   EXPECT_THAT(Eval("1 + __log2(1, 2)"),
               IsError("no matching function for call to '__log2': requires 1 "
                       "argument(s), but 2 argument(s) were provided\n"
-                      "1 + __log2(1, 2)\n"
-                      "    ^"));
+                      "   1 | 1 + __log2(1, 2)\n"
+                      "     |     ^"));
 
   EXPECT_THAT(Eval("dummy(1)"),
               IsError("function 'dummy' is not a supported builtin intrinsic"));
@@ -2853,7 +2858,7 @@ TEST_F(EvalTest, TestDereferencedType) {
     ASSERT_TRUE(ret.lldb_DIL_error.Success());
     ASSERT_TRUE(ret.lldb_value.has_value());
 
-    ASSERT_STREQ(ret.lldb_DIL_value.GetTypeName(), "TPair");
+    // ASSERT_STREQ(ret.lldb_DIL_value.GetTypeName(), "TPair");
     ASSERT_STREQ(ret.lldb_value.value().GetTypeName(), "TPair");
   }
 }
@@ -3174,28 +3179,30 @@ TEST_F(EvalTest, TestBuiltinFunction_findnonnull) {
   EXPECT_THAT(Eval("__findnonnull(pointer_to_pointers+3, 2)"), IsEqual("1"));
 
   EXPECT_THAT(Eval("__findnonnull(0, 0)"),
-              IsError("no known conversion from 'int' to 'T*' for 1st argument "
-                      "of __findnonnull()\n"
-                      "__findnonnull(0, 0)\n"
-                      "              ^"));
+              IsError("<user expression 0>:1:15: no known conversion from 'int'"
+                      " to 'T*' for 1st argument of __findnonnull()\n"
+                      "   1 | __findnonnull(0, 0)\n"
+                      "     |               ^"));
   EXPECT_THAT(
       Eval("__findnonnull(1.0f, 0)"),
-      IsError("no known conversion from 'float' to 'T*' for 1st argument "
-              "of __findnonnull()\n"
-              "__findnonnull(1.0f, 0)\n"
-              "              ^"));
+      IsError("<user expression 0>:1:15: no known conversion from 'float' to"
+              " 'T*' for 1st argument of __findnonnull()\n"
+              "   1 | __findnonnull(1.0f, 0)\n"
+              "     |               ^"));
   EXPECT_THAT(
       Eval("__findnonnull(array_of_pointers, -1)"),
-      IsError("passing in a buffer size ('-1') that is negative or in excess "
-              "of 100 million to __findnonnull() is not allowed.\n"
-              "__findnonnull(array_of_pointers, -1)\n"
-              "                                 ^"));
+      IsError("<user expression 0>:1:34: passing in a buffer size ('-1') that "
+              "is negative or in excess of 100 million to __findnonnull() is "
+              "not allowed.\n"
+              "   1 | __findnonnull(array_of_pointers, -1)\n"
+              "     |                                  ^"));
   EXPECT_THAT(
       Eval("__findnonnull(array_of_pointers, 100000001)"),
-      IsError("passing in a buffer size ('100000001') that is negative "
-              "or in excess of 100 million to __findnonnull() is not allowed.\n"
-              "__findnonnull(array_of_pointers, 100000001)\n"
-              "                                 ^"));
+      IsError("<user expression 0>:1:34: passing in a buffer size ('100000001')"
+              " that is negative or in excess of 100 million to __findnonnull()"
+              " is not allowed.\n"
+              "   1 | __findnonnull(array_of_pointers, 100000001)\n"
+              "     |                                  ^"));
 
   if (process_.GetAddressByteSize() == 4) {
     EXPECT_THAT(Eval("__findnonnull(array_of_uint8, 6)"), IsEqual("0"));


### PR DESCRIPTION
Finish applying various changes, corresponding to reviewer requests for the upstream Local Vars PR:

- Remove m_use_dynamic & GetUseDynamic() from IdentifierNode class.
- Rename Interpreter::DILEval to Interpreter::Evaluate; remove ununsed target_sp argument.
- Rename "DILEvalNode" method to "EvalNode".
- Remove code in Interpreter::Visit(IdentifierNode) that automatically dereferenced reference variables.
- Update ParseNestedNameSpecifier to use  switch statement basedon the token kind (reduce calls to CurToken().GetKind()).
- Update error handling:
  - Add new class, DILDiagnosticError. Replace calls to FormatDiagnostics with llvm::make_error<DILDiagnosticError>(...).
  - Change m_error, in DILParser class, from lldb::Status& to llvm::Error&.
  - Change DILParser::Run to return ASTNodeUP (remove the llvm::Expected...); do the error checking in DILParser::Parse, which calls Run.
  - Add err_len parameter to DILParser::BailOut & remove the now-unused ErrorCode argument; update all call sites appropriately. all calls. R
  - Remove unused overload version of DILPaser::BailOut.
- Updated DILTests.cpp error messages; changed some tests of reference variables to expect IsOK rather than the dereferenced value.